### PR TITLE
Enable smoother NPM distribution.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Designer.
  -  Graceful error recovery. Malformed CSS will be parsed by this
 parser as closely as possible to the way a browser would parse it.
 
+### Installing
+
+With `node` and `npm` installed, run the following command:
+
+```sh
+npm install shady-css-parser
+```
+
 ### Building
 
 Run the following commands from the project root:

--- a/index.js
+++ b/index.js
@@ -8,5 +8,4 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-require('babel/register');
-module.exports = require('./src/shady-css');
+module.exports = require('./dist/shady-css');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shady-css-parser",
-  "version": "0.0.1",
-  "description": "Shady CSS Parser",
+  "version": "0.0.4",
+  "description": "A fast, small and flexible CSS parser.",
   "main": "index.js",
   "devDependencies": {
     "babel-core": "^6.4.0",
@@ -28,6 +28,10 @@
     "gulp-uglify": "^1.4.2",
     "gulp-watch": "^4.3.5",
     "mocha": "^2.3.3"
+  },
+  "scripts": {
+    "prepublish": "gulp",
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",

--- a/shady-css.html
+++ b/shady-css.html
@@ -1,1 +1,1 @@
-<script src="dist/shady-css.js"></script>
+<script src="dist/shady-css.concat.js"></script>


### PR DESCRIPTION
- `gulp` now generates Node-friendly artifacts.
- `shady-css.js` artifact renamed to `shady-css.concat.js`.
- `npm prepublish` and `npm test` commands now do the right thing.
- Now includes explicit `.npmignore` file.

/cc @justinfagnani 
