### PR TITLE
Fix colon and semicolon issues.

### DIFF
--- a/src/shady-css/common.js
+++ b/src/shady-css/common.js
@@ -18,7 +18,7 @@ const matcher = {
   whitespace: /\s/,
   whitespaceGreedy: /(\s+)/g,
   commentGreedy: /(\*\/)/g,
-  boundary: /[\(\)\{\}'"@;\s]/,
+  boundary: /[\(\)\{\}'"@;:\s]/,
   stringBoundary: /['"]/
 };
 

--- a/src/shady-css/parser.js
+++ b/src/shady-css/parser.js
@@ -76,14 +76,15 @@ class Parser {
     if (tokenizer.currentToken.is(Token.type.whitespace)) {
       tokenizer.advance();
       return null;
-    } else if (tokenizer.currentToken.is(Token.type.comment)) {
-      return this.parseComment(tokenizer)
 
-    } else if (tokenizer.currentToken.is(Token.type.propertyBoundary)) {
-      return this.parseUnknown(tokenizer);
+    } else if (tokenizer.currentToken.is(Token.type.comment)) {
+      return this.parseComment(tokenizer);
 
     } else if (tokenizer.currentToken.is(Token.type.word)) {
       return this.parseDeclarationOrRuleset(tokenizer);
+
+    } else if (tokenizer.currentToken.is(Token.type.propertyBoundary)) {
+      return this.parseUnknown(tokenizer);
 
     } else if (tokenizer.currentToken.is(Token.type.at)) {
       return this.parseAtRule(tokenizer);
@@ -113,12 +114,8 @@ class Parser {
     let start = tokenizer.advance();
     let end;
 
-    while (tokenizer.currentToken) {
-      if (tokenizer.currentToken.is(Token.type.boundary) &&
-          !tokenizer.currentToken.is(Token.type.semicolon)) {
-        break;
-      }
-
+    while (tokenizer.currentToken &&
+           tokenizer.currentToken.is(Token.type.boundary)) {
       end = tokenizer.advance();
     }
 

--- a/src/shady-css/token.js
+++ b/src/shady-css/token.js
@@ -59,6 +59,10 @@ Token.type = {
   // [};] are property boundaries:
   closeBrace: 1024 | 32 | 16,
   semicolon: 2048 | 32 | 16,
+  // : is a chimaeric abomination:
+  // foo:bar{}
+  // foo:bar;
+  colon: 4096 | 16 | 8
 };
 
 /**

--- a/test/debug-node-factory.js
+++ b/test/debug-node-factory.js
@@ -1,4 +1,5 @@
 import { NodeFactory } from '../src/shady-css/node-factory';
+import { nodeType } from '../src/shady-css/common';
 
 class DebugNodeFactory extends NodeFactory {}
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -48,6 +48,14 @@ let customProperties = `
 }
 `;
 
+let extraSemicolons = `
+:host {
+  margin: 0;;;
+  padding: 0;;
+  ;display: block;
+};
+`
+
 let minifiedRuleset = '.foo{bar:baz}div .qux{vim:fet;}';
 
 let psuedoRuleset = '.foo:bar:not(#rif){baz:qux}';
@@ -72,6 +80,7 @@ export {
   atRules,
   keyframes,
   customProperties,
+  extraSemicolons,
   minifiedRuleset,
   psuedoRuleset,
   dataUriRuleset,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -15,16 +15,15 @@ function expectTokenType(token, type) {
   expect(token.type).to.be.equal(type);
 }
 
-function expectTokenTypeOrder(lexer, types) {
-  let lexedTypes = [];
-  let _types = types.slice();
+function expectTokenSequence(lexer, sequence) {
+  let lexedSequence = [];
   let token;
 
   while (token = lexer.advance()) {
-    lexedTypes.push(token.type);
+    lexedSequence.push(token.type, lexer.slice(token));
   }
 
-  expect(lexedTypes).to.be.eql(types);
+  expect(lexedSequence).to.be.eql(sequence);
 }
 
-export { expectTokenType, expectTokenTypeOrder };
+export { expectTokenType, expectTokenSequence };

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -112,9 +112,24 @@ describe('Parser', () => {
         ])),
         nodeFactory.comment('/* unclosed\n@fiz {\n  --huk: {\n    /* buz */'),
         nodeFactory.declaration('baz', nodeFactory.expression('lur')),
-        nodeFactory.discarded('};\n'),
-        nodeFactory.discarded('}\n'),
+        nodeFactory.discarded('};'),
+        nodeFactory.discarded('}'),
         nodeFactory.atRule('gak', 'wiz', null)
+      ]));
+    });
+
+    it('disregards extra semi-colons', () => {
+      expect(parser.parse(fixtures.extraSemicolons))
+          .to.be.eql(nodeFactory.stylesheet([
+        nodeFactory.ruleset(':host', nodeFactory.rulelist([
+          nodeFactory.declaration('margin', nodeFactory.expression('0')),
+          nodeFactory.discarded(';;'),
+          nodeFactory.declaration('padding', nodeFactory.expression('0')),
+          nodeFactory.discarded(';'),
+          nodeFactory.discarded(';'),
+          nodeFactory.declaration('display', nodeFactory.expression('block')),
+        ])),
+        nodeFactory.discarded(';')
       ]));
     });
   });

--- a/test/tokenizer-test.js
+++ b/test/tokenizer-test.js
@@ -45,56 +45,95 @@ describe('Tokenizer', () => {
 
   describe('when tokenizing standard CSS structures', () => {
     it('can tokenize a basic ruleset', () => {
-      helpers.expectTokenTypeOrder(new Tokenizer(fixtures.basicRuleset), [
-        Token.type.whitespace, // '\n'
-        Token.type.word,       // 'body'
-        Token.type.whitespace, // ' '
-        Token.type.openBrace,  // '{'
-        Token.type.whitespace, // '\n  '
-        Token.type.word,       // 'margin'
-        Token.type.whitespace, // ' '
-        Token.type.word,       // '0'
-        Token.type.semicolon,  // ';'
-        Token.type.whitespace, // '\n  '
-        Token.type.word,       // 'padding'
-        Token.type.whitespace, // ' '
-        Token.type.word,       // '0px'
-        Token.type.whitespace, // '\n'
-        Token.type.closeBrace, // '}'
-        Token.type.whitespace  // '\n'
+      helpers.expectTokenSequence(new Tokenizer(fixtures.basicRuleset), [
+        Token.type.whitespace, '\n',
+        Token.type.word,       'body',
+        Token.type.whitespace, ' ',
+        Token.type.openBrace,  '{',
+        Token.type.whitespace, '\n  ',
+        Token.type.word,       'margin',
+        Token.type.colon,            ':',
+        Token.type.whitespace, ' ',
+        Token.type.word,       '0',
+        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n  ',
+        Token.type.word,       'padding',
+        Token.type.colon,            ':',
+        Token.type.whitespace, ' ',
+        Token.type.word,       '0px',
+        Token.type.whitespace, '\n',
+        Token.type.closeBrace, '}',
+        Token.type.whitespace, '\n'
       ]);
     });
 
     it('can tokenize @rules', () => {
-      helpers.expectTokenTypeOrder(new Tokenizer(fixtures.atRules), [
-        Token.type.whitespace,       // '\n'
-        Token.type.at,               // '@'
-        Token.type.word,             // 'import'
-        Token.type.whitespace,       // ' '
-        Token.type.word,             // 'url'
-        Token.type.openParenthesis,  // '('
-        Token.type.string,           // '\'foo.css\''
-        Token.type.closeParenthesis, // ')'
-        Token.type.semicolon,        // ';'
-        Token.type.whitespace,       // '\n\n',
-        Token.type.at,               // '@',
-        Token.type.word,             // 'font-face'
-        Token.type.whitespace,       // ' '
-        Token.type.openBrace,        // '{'
-        Token.type.whitespace,       // '\n  ',
-        Token.type.word,             // 'font-family'
-        Token.type.whitespace,       // ' '
-        Token.type.word,             // 'foo'
-        Token.type.semicolon,        // ';'
-        Token.type.whitespace,       // '\n'
-        Token.type.closeBrace,       // '}'
-        Token.type.whitespace,       // '\n\n'
-        Token.type.at,               // '@'
-        Token.type.word,             // 'word'
-        Token.type.whitespace,       // ' '
-        Token.type.string,           // '\'foo\''
-        Token.type.semicolon,        // ';'
-        Token.type.whitespace,       // '\n'
+      helpers.expectTokenSequence(new Tokenizer(fixtures.atRules), [
+        Token.type.whitespace,       '\n',
+        Token.type.at,               '@',
+        Token.type.word,             'import',
+        Token.type.whitespace,       ' ',
+        Token.type.word,             'url',
+        Token.type.openParenthesis,  '(',
+        Token.type.string,           '\'foo.css\'',
+        Token.type.closeParenthesis, ')',
+        Token.type.semicolon,        ';',
+        Token.type.whitespace,       '\n\n',
+        Token.type.at,               '@',
+        Token.type.word,             'font-face',
+        Token.type.whitespace,       ' ',
+        Token.type.openBrace,        '{',
+        Token.type.whitespace,       '\n  ',
+        Token.type.word,             'font-family',
+        Token.type.colon,            ':',
+        Token.type.whitespace,       ' ',
+        Token.type.word,             'foo',
+        Token.type.semicolon,        ';',
+        Token.type.whitespace,       '\n',
+        Token.type.closeBrace,       '}',
+        Token.type.whitespace,       '\n\n',
+        Token.type.at,               '@',
+        Token.type.word,             'charset',
+        Token.type.whitespace,       ' ',
+        Token.type.string,           '\'foo\'',
+        Token.type.semicolon,        ';',
+        Token.type.whitespace,       '\n'
+      ]);
+    });
+
+    it('navigates pathological boundary usage', () => {
+      helpers.expectTokenSequence(new Tokenizer(fixtures.extraSemicolons), [
+        Token.type.whitespace, '\n',
+        Token.type.colon,      ':',
+        Token.type.word,       'host',
+        Token.type.whitespace, ' ',
+        Token.type.openBrace,  '{',
+        Token.type.whitespace, '\n  ',
+        Token.type.word,       'margin',
+        Token.type.colon,      ':',
+        Token.type.whitespace, ' ',
+        Token.type.word,       '0',
+        Token.type.semicolon,  ';',
+        Token.type.semicolon,  ';',
+        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n  ',
+        Token.type.word,       'padding',
+        Token.type.colon,      ':',
+        Token.type.whitespace, ' ',
+        Token.type.word,       '0',
+        Token.type.semicolon,  ';',
+        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n  ',
+        Token.type.semicolon,  ';',
+        Token.type.word,       'display',
+        Token.type.colon,      ':',
+        Token.type.whitespace, ' ',
+        Token.type.word,       'block',
+        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n',
+        Token.type.closeBrace, '}',
+        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n'
       ]);
     });
   });


### PR DESCRIPTION
- When handling discardable sub-sequences of tokens, the parser was
  incorrectly advancing in the case where a semi-colon was detected as
  the next token. This has been fixed.
- When tokenizing words, the tokenizer was being incorrectly inclusive
  of colons. This was resulting in word tokens that contained the colon
  character. This did not affect the parser because of a parsing
  "cheat" that we do to distinguish declarations from selectors, but
  any extended parsing may have been left with unexpected tokens to
  work with. This has been fixed.

Fixed https://github.com/PolymerLabs/shady-css-parser/issues/5
