### PR TITLE
Fix parsing declaractions without expr value.

### DIFF
--- a/src/shady-css/parser.js
+++ b/src/shady-css/parser.js
@@ -223,6 +223,7 @@ class Parser {
 
         if (!ruleStart) {
           ruleStart = tokenizer.advance();
+          ruleEnd = ruleStart;
         } else {
           ruleEnd = tokenizer.advance();
         }
@@ -231,9 +232,11 @@ class Parser {
 
     // A ruleset never contains or ends with a semi-colon.
     if (tokenizer.currentToken.is(Token.type.propertyBoundary)) {
-      let declarationName = tokenizer.slice(ruleStart, colon.previous);
+      let declarationName = tokenizer.slice(
+          ruleStart, colon ? colon.previous : ruleEnd);
       // TODO(cdata): is .trim() bad for performance?
-      let expressionValue = tokenizer.slice(colon.next, ruleEnd).trim();
+      let expressionValue =
+          colon && tokenizer.slice(colon.next, ruleEnd).trim();
 
       if (tokenizer.currentToken.is(Token.type.semicolon)) {
         tokenizer.advance();
@@ -241,7 +244,7 @@ class Parser {
 
       return this.nodeFactory.declaration(
           declarationName,
-          this.nodeFactory.expression(expressionValue));
+          expressionValue && this.nodeFactory.expression(expressionValue));
     // This is the case for a mixin-like structure:
     } else if (colon && colon === ruleEnd) {
       let rulelist = this.parseRulelist(tokenizer);
@@ -252,7 +255,7 @@ class Parser {
 
       return this.nodeFactory.declaration(
           tokenizer.slice(ruleStart, ruleEnd.previous), rulelist);
-    // Otherwise, this is a ruleset:kkkkk
+    // Otherwise, this is a ruleset:
     } else {
       return this.nodeFactory.ruleset(
           tokenizer.slice(ruleStart, ruleEnd),

--- a/src/shady-css/stringifier.js
+++ b/src/shady-css/stringifier.js
@@ -89,7 +89,9 @@ class Stringifier extends NodeVisitor {
    * @return {string} The stringified CSS of the Declaration.
    */
   [nodeType.declaration](declaration) {
-    return `${declaration.name}:${this.visit(declaration.value)};`;
+    return declaration.value != null ?
+      `${declaration.name}:${this.visit(declaration.value)};` :
+      `${declaration.name};`;
   }
 
   /**

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -54,7 +54,16 @@ let extraSemicolons = `
   padding: 0;;
   ;display: block;
 };
-`
+`;
+
+let declarationsWithNoValue = `
+foo;
+bar 20px;
+
+div {
+  baz;
+}
+`;
 
 let minifiedRuleset = '.foo{bar:baz}div .qux{vim:fet;}';
 
@@ -81,6 +90,7 @@ export {
   keyframes,
   customProperties,
   extraSemicolons,
+  declarationsWithNoValue,
   minifiedRuleset,
   psuedoRuleset,
   dataUriRuleset,

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -73,6 +73,17 @@ describe('Parser', () => {
       ]))
     });
 
+    it('can parse declarations with no value', () => {
+      expect(parser.parse(fixtures.declarationsWithNoValue))
+          .to.be.eql(nodeFactory.stylesheet([
+        nodeFactory.declaration('foo', null),
+        nodeFactory.declaration('bar 20px', null),
+        nodeFactory.ruleset('div', nodeFactory.rulelist([
+          nodeFactory.declaration('baz', null)
+        ]))
+      ]));
+    });
+
     it('can parse minified rulelists', () => {
       expect(parser.parse(fixtures.minifiedRuleset))
           .to.be.eql(nodeFactory.stylesheet([

--- a/test/stringifier-test.js
+++ b/test/stringifier-test.js
@@ -90,6 +90,12 @@ describe('Stringifier', () => {
           '@keyframes foo{from{fiz:0%;}99.9%{fiz:100px;buz:true;}}');
     });
 
+    it('can stringify declarations without value', () => {
+      let cssText =
+          stringifier.stringify(parser.parse(fixtures.declarationsWithNoValue));
+      expect(cssText).to.be.eql('foo;bar 20px;div{baz;}');
+    });
+
     it('can stringify custom properties', () => {
       let cssText = stringifier.stringify(
           parser.parse(fixtures.customProperties));


### PR DESCRIPTION
Fixes #11 

If a declaration has no value, the `value` property of the `declaration` node will be `null`.
