### PR TITLE
[3] Automatically format with clang-format, apply tslint

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+# This breaks async functions sometimes, see
+#     https://github.com/Polymer/polymer-analyzer/pull/393
+# BinPackParameters: false

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^8.0.13",
     "chai": "^4.1.0",
     "chai-subset": "^1.5.0",
+    "clang-format": "^1.0.53",
     "mocha": "^3.0.0",
     "source-map-support": "^0.4.15",
     "typescript": "^2.4.1",
@@ -20,7 +21,8 @@
     "prepublishOnly": "npm run build",
     "build": "tsc",
     "test": "npm run build && mocha --require source-map-support/register dist/test/*.js",
-    "test:watch": "watchy -w src/ -- npm test --loglevel=silent"
+    "test:watch": "watchy -w src/ -- npm test --loglevel=silent",
+    "format": "find src | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clang-format": "^1.0.53",
     "mocha": "^3.0.0",
     "source-map-support": "^0.4.15",
+    "tslint": "^5.5.0",
     "typescript": "^2.4.1",
     "watchy": "^0.6.7"
   },
@@ -21,7 +22,9 @@
     "prepublishOnly": "npm run build",
     "build": "tsc",
     "test": "npm run build && mocha --require source-map-support/register dist/test/*.js",
+    "test:sloppy": "tsc || echo '' && mocha --require source-map-support/register dist/test/*.js",
     "test:watch": "watchy -w src/ -- npm test --loglevel=silent",
+    "lint": "tslint -p ./",
     "format": "find src | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
   },
   "repository": {

--- a/src/shady-css.ts
+++ b/src/shady-css.ts
@@ -1,17 +1,18 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-export { nodeType } from './shady-css/common';
-export { Token } from './shady-css/token';
-export { Tokenizer } from './shady-css/tokenizer';
-export { NodeFactory } from './shady-css/node-factory';
-export { NodeVisitor } from './shady-css/node-visitor';
-export { Stringifier } from './shady-css/stringifier';
-export { Parser } from './shady-css/parser';
+export {nodeType} from './shady-css/common';
+export {NodeFactory} from './shady-css/node-factory';
+export {NodeVisitor} from './shady-css/node-visitor';
+export {Parser} from './shady-css/parser';
+export {Stringifier} from './shady-css/stringifier';
+export {Token} from './shady-css/token';
+export {Tokenizer} from './shady-css/tokenizer';

--- a/src/shady-css/common.ts
+++ b/src/shady-css/common.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 /**
@@ -23,27 +24,29 @@ const matcher = {
  * An enumeration of Node types.
  */
 export enum nodeType {
-  stylesheet= 'stylesheet',
-  comment= 'comment',
-  atRule= 'atRule',
-  ruleset= 'ruleset',
-  expression= 'expression',
-  declaration= 'declaration',
-  rulelist= 'rulelist',
-  discarded= 'discarded'
-};
+  stylesheet = 'stylesheet',
+  comment = 'comment',
+  atRule = 'atRule',
+  ruleset = 'ruleset',
+  expression = 'expression',
+  declaration = 'declaration',
+  rulelist = 'rulelist',
+  discarded = 'discarded'
+}
+;
 
-export type Node = Stylesheet | AtRule | Comment | Rulelist | Ruleset | Expression | Declaration | Discarded;
+export type Node = Stylesheet | AtRule | Comment | Rulelist | Ruleset |
+    Expression | Declaration | Discarded;
 export type Rule = Ruleset | Declaration | AtRule | Discarded | Comment;
 
 /** A Stylesheet node. */
 export interface Stylesheet {
   type: nodeType.stylesheet,
 
-  /**
-   * The list of rules that appear at the top level of the stylesheet.
-   */
-  rules: Rule[];
+      /**
+       * The list of rules that appear at the top level of the stylesheet.
+       */
+      rules: Rule[];
 
   range: Range;
 }
@@ -55,7 +58,7 @@ export interface AtRule {
   nameRange: Range;
   /** The "parameters" of the At Rule (e.g., `utf8`) */
   parameters: string;
-  parametersRange: Range | undefined;
+  parametersRange: Range|undefined;
   /** The Rulelist node (if any) of the At Rule. */
   rulelist: Rulelist|undefined;
 
@@ -120,7 +123,7 @@ export interface Declaration {
    * Either an Expression node, or a Rulelist node, that
    * corresponds to the value of the Declaration.
    */
-  value:  Expression | Rulelist | undefined;
+  value: Expression|Rulelist|undefined;
 
   range: Range;
 }
@@ -167,6 +170,4 @@ export interface NodeTypeMap {
   'discarded': Discarded;
 }
 
-
-
-export { matcher };
+export {matcher};

--- a/src/shady-css/common.ts
+++ b/src/shady-css/common.ts
@@ -33,7 +33,7 @@ export enum nodeType {
   rulelist = 'rulelist',
   discarded = 'discarded'
 }
-;
+
 
 export type Node = Stylesheet | AtRule | Comment | Rulelist | Ruleset |
     Expression | Declaration | Discarded;
@@ -41,12 +41,12 @@ export type Rule = Ruleset | Declaration | AtRule | Discarded | Comment;
 
 /** A Stylesheet node. */
 export interface Stylesheet {
-  type: nodeType.stylesheet,
+  type: nodeType.stylesheet;
 
-      /**
-       * The list of rules that appear at the top level of the stylesheet.
-       */
-      rules: Rule[];
+  /**
+   * The list of rules that appear at the top level of the stylesheet.
+   */
+  rules: Rule[];
 
   range: Range;
 }
@@ -111,7 +111,7 @@ export interface Ruleset {
  * A Declaration node.
  */
 export interface Declaration {
-  type: nodeType.declaration
+  type: nodeType.declaration;
 
   /** The property name of the Declaration (e.g., `color`). */
   name: string;

--- a/src/shady-css/node-factory.ts
+++ b/src/shady-css/node-factory.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {AtRule, Comment, Declaration, Discarded, Expression, nodeType, Range, Rule, Rulelist, Ruleset, Stylesheet} from './common';
@@ -22,7 +23,7 @@ class NodeFactory {
    * level of the stylesheet.
    */
   stylesheet(rules: Rule[], range: Range): Stylesheet {
-    return { type: nodeType.stylesheet, rules, range };
+    return {type: nodeType.stylesheet, rules, range};
   }
 
   /**
@@ -31,9 +32,19 @@ class NodeFactory {
    * @param parameters The "parameters" of the At Rule (e.g., `utf8`)
    * @param rulelist The Rulelist node (if any) of the At Rule.
    */
-  atRule(name: string, parameters: string, rulelist: Rulelist|
-        undefined=undefined, nameRange: Range, parametersRange: Range|undefined, range: Range): AtRule {
-    return { type: nodeType.atRule, name, parameters, rulelist, nameRange, parametersRange, range };
+  atRule(
+      name: string, parameters: string,
+      rulelist: Rulelist|undefined = undefined, nameRange: Range,
+      parametersRange: Range|undefined, range: Range): AtRule {
+    return {
+      type: nodeType.atRule,
+      name,
+      parameters,
+      rulelist,
+      nameRange,
+      parametersRange,
+      range
+    };
   }
 
   /**
@@ -42,7 +53,7 @@ class NodeFactory {
    * opening and closing comment signature.
    */
   comment(value: string, range: Range): Comment {
-    return { type: nodeType.comment, value, range };
+    return {type: nodeType.comment, value, range};
   }
 
   /**
@@ -50,7 +61,7 @@ class NodeFactory {
    * @param rules An array of the Rule nodes found within the Ruleset.
    */
   rulelist(rules: Rule[], range: Range): Rulelist {
-    return { type: nodeType.rulelist, rules, range };
+    return {type: nodeType.rulelist, rules, range};
   }
 
   /**
@@ -59,8 +70,10 @@ class NodeFactory {
    * (e.g., `#foo > .bar`).
    * @param rulelist The Rulelist node that corresponds to the Selector.
    */
-  ruleset(selector: string, rulelist: Rulelist, selectorRange: Range, range: Range): Ruleset {
-    return { type: nodeType.ruleset, selector, rulelist, selectorRange, range };
+  ruleset(
+      selector: string, rulelist: Rulelist, selectorRange: Range,
+      range: Range): Ruleset {
+    return {type: nodeType.ruleset, selector, rulelist, selectorRange, range};
   }
 
   /**
@@ -69,8 +82,10 @@ class NodeFactory {
    * @param value Either an Expression node, or a Rulelist node, that
    * corresponds to the value of the Declaration.
    */
-  declaration(name: string, value: Expression|Rulelist|undefined, nameRange: Range, range: Range): Declaration {
-    return { type: nodeType.declaration, name, value, nameRange, range};
+  declaration(
+      name: string, value: Expression|Rulelist|undefined, nameRange: Range,
+      range: Range): Declaration {
+    return {type: nodeType.declaration, name, value, nameRange, range};
   }
 
   /**
@@ -79,7 +94,7 @@ class NodeFactory {
    * `url(img.jpg)`)
    */
   expression(text: string, range: Range): Expression {
-    return { type: nodeType.expression, text, range };
+    return {type: nodeType.expression, text, range};
   }
 
   /**
@@ -88,8 +103,8 @@ class NodeFactory {
    * @param text The text content that is discarded.
    */
   discarded(text: string, range: Range): Discarded {
-    return { type: nodeType.discarded, text, range};
+    return {type: nodeType.discarded, text, range};
   }
 }
 
-export { NodeFactory };
+export {NodeFactory};

--- a/src/shady-css/node-visitor.ts
+++ b/src/shady-css/node-visitor.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 /**
@@ -13,7 +14,7 @@
  * Extend the NodeVisitor class to implement useful tree traversal operations
  * such as stringification.
  */
-class NodeVisitor<Node extends {type: any}, ReturnValue> {
+class NodeVisitor<Node extends{type: any}, ReturnValue> {
   private path_: Node[];
   /**
    * Create a NodeVisitor instance.
@@ -40,7 +41,8 @@ class NodeVisitor<Node extends {type: any}, ReturnValue> {
    */
   visit(node: Node) {
     let result: ReturnValue|undefined;
-    const callback: ((token: Node)=>ReturnValue) | undefined = (this as any)[node.type];
+    const callback: ((token: Node) => ReturnValue)|undefined =
+        (this as any)[node.type];
     if (callback) {
       this.path_.push(node);
       result = (this as any)[node.type](node);
@@ -50,4 +52,4 @@ class NodeVisitor<Node extends {type: any}, ReturnValue> {
   }
 }
 
-export { NodeVisitor };
+export {NodeVisitor};

--- a/src/shady-css/parser.ts
+++ b/src/shady-css/parser.ts
@@ -56,10 +56,10 @@ class Parser {
    *   Declaration and Discarded nodes may be present in the list.
    */
   parseRules(tokenizer: Tokenizer): Rule[] {
-    let rules = [];
+    const rules = [];
 
     while (tokenizer.currentToken) {
-      let rule = this.parseRule(tokenizer);
+      const rule = this.parseRule(tokenizer);
 
       if (rule) {
         rules.push(rule);
@@ -122,7 +122,7 @@ class Parser {
    * @param tokenizer A Tokenizer instance.
    */
   parseUnknown(tokenizer: Tokenizer): Discarded|null {
-    let start = tokenizer.advance();
+    const start = tokenizer.advance();
     let end;
 
     if (start === null) {
@@ -160,7 +160,7 @@ class Parser {
       } else if (!name && tokenizer.currentToken.is(Token.type.at)) {
         // Discard the @:
         tokenizer.advance();
-        let start = tokenizer.currentToken;
+        const start = tokenizer.currentToken;
         let end;
 
         while (tokenizer.currentToken &&
@@ -206,7 +206,7 @@ class Parser {
    * @param tokenizer A Tokenizer instance.
    */
   parseRulelist(tokenizer: Tokenizer): Rulelist {
-    let rules = [];
+    const rules = [];
 
     const start = tokenizer.currentToken!.start;
     let endToken;
@@ -219,7 +219,7 @@ class Parser {
         tokenizer.advance();
         break;
       } else {
-        let rule = this.parseRule(tokenizer);
+        const rule = this.parseRule(tokenizer);
         if (rule) {
           rules.push(rule);
         }
@@ -308,7 +308,7 @@ class Parser {
           declarationName, expression, nameRange, range);
       // This is the case for a mixin-like structure:
     } else if (colon && colon === ruleEnd) {
-      let rulelist = this.parseRulelist(tokenizer);
+      const rulelist = this.parseRulelist(tokenizer);
 
       if (tokenizer.currentToken.is(Token.type.semicolon)) {
         tokenizer.advance();

--- a/src/shady-css/parser.ts
+++ b/src/shady-css/parser.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {AtRule, Comment, Declaration, Discarded, Rule, Rulelist, Ruleset, Stylesheet} from './common';
@@ -43,7 +44,8 @@ class Parser {
    * @param tokenizer A Tokenizer instance.
    */
   parseStylesheet(tokenizer: Tokenizer): Stylesheet {
-    return this.nodeFactory.stylesheet(this.parseRules(tokenizer), {start: 0, end: tokenizer.cssText.length});
+    return this.nodeFactory.stylesheet(
+        this.parseRules(tokenizer), {start: 0, end: tokenizer.cssText.length});
   }
 
   /**
@@ -104,7 +106,7 @@ class Parser {
    * Consumes tokens from a Tokenizer to parse a Comment node.
    * @param tokenizer A Tokenizer instance.
    */
-  parseComment(tokenizer: Tokenizer): Comment | null {
+  parseComment(tokenizer: Tokenizer): Comment|null {
     const token = tokenizer.advance();
     if (token === null) {
       return null;
@@ -119,7 +121,7 @@ class Parser {
    * malformed CSS conditions.
    * @param tokenizer A Tokenizer instance.
    */
-  parseUnknown(tokenizer: Tokenizer): Discarded | null {
+  parseUnknown(tokenizer: Tokenizer): Discarded|null {
     let start = tokenizer.advance();
     let end;
 
@@ -140,7 +142,7 @@ class Parser {
    * Consumes tokens from a Tokenizer to parse an At Rule node.
    * @param tokenizer A Tokenizer instance.
    */
-  parseAtRule(tokenizer: Tokenizer): AtRule | null {
+  parseAtRule(tokenizer: Tokenizer): AtRule|null {
     let name = undefined;
     let nameRange = undefined;
     let rulelist = undefined;
@@ -189,11 +191,11 @@ class Parser {
     let parameters = '';
     if (parametersStart) {
       parametersRange = tokenizer.getRange(parametersStart, parametersEnd);
-      parameters = tokenizer.cssText.slice(parametersRange.start, parametersRange.end);
+      parameters =
+          tokenizer.cssText.slice(parametersRange.start, parametersRange.end);
     }
-    const end = tokenizer.currentToken ?
-        tokenizer.currentToken.previous!.end :
-        tokenizer.cssText.length;
+    const end = tokenizer.currentToken ? tokenizer.currentToken.previous!.end :
+                                         tokenizer.cssText.length;
 
     return this.nodeFactory.atRule(
         name, parameters, rulelist, nameRange, parametersRange, {start, end});
@@ -235,7 +237,7 @@ class Parser {
    * a Ruleset node, as appropriate.
    * @param tokenizer A Tokenizer node.
    */
-  parseDeclarationOrRuleset(tokenizer: Tokenizer): Ruleset | Declaration | null {
+  parseDeclarationOrRuleset(tokenizer: Tokenizer): Ruleset|Declaration|null {
     let ruleStart = null;
     let ruleEnd = null;
     let colon = null;
@@ -253,8 +255,9 @@ class Parser {
                !tokenizer.currentToken.is(Token.type.closeParenthesis)) {
           tokenizer.advance();
         }
-      } else if (tokenizer.currentToken.is(Token.type.openBrace) ||
-                 tokenizer.currentToken.is(Token.type.propertyBoundary)) {
+      } else if (
+          tokenizer.currentToken.is(Token.type.openBrace) ||
+          tokenizer.currentToken.is(Token.type.propertyBoundary)) {
         break;
       } else {
         if (tokenizer.currentToken.is(Token.type.colon)) {
@@ -277,17 +280,19 @@ class Parser {
 
     // A ruleset never contains or ends with a semi-colon.
     if (tokenizer.currentToken.is(Token.type.propertyBoundary)) {
-      const nameRange = tokenizer.getRange(
-          ruleStart!, colon ? colon.previous : ruleEnd);
-      const declarationName = tokenizer.cssText.slice(
-          nameRange.start, nameRange.end);
+      const nameRange =
+          tokenizer.getRange(ruleStart!, colon ? colon.previous : ruleEnd);
+      const declarationName =
+          tokenizer.cssText.slice(nameRange.start, nameRange.end);
 
       let expression = undefined;
       if (colon && colon.next) {
         const rawExpressionRange = tokenizer.getRange(colon.next, ruleEnd);
         const expressionRange = tokenizer.trimRange(rawExpressionRange);
-        const expressionValue = tokenizer.cssText.slice(expressionRange.start, expressionRange.end);
-        expression = this.nodeFactory.expression(expressionValue, expressionRange);
+        const expressionValue =
+            tokenizer.cssText.slice(expressionRange.start, expressionRange.end);
+        expression =
+            this.nodeFactory.expression(expressionValue, expressionRange);
       }
 
       if (tokenizer.currentToken.is(Token.type.semicolon)) {
@@ -296,10 +301,12 @@ class Parser {
 
       const range = tokenizer.trimRange(tokenizer.getRange(
           ruleStart!,
-          tokenizer.currentToken && tokenizer.currentToken.previous || ruleEnd));
+          tokenizer.currentToken && tokenizer.currentToken.previous ||
+              ruleEnd));
 
-      return this.nodeFactory.declaration(declarationName, expression, nameRange, range);
-    // This is the case for a mixin-like structure:
+      return this.nodeFactory.declaration(
+          declarationName, expression, nameRange, range);
+      // This is the case for a mixin-like structure:
     } else if (colon && colon === ruleEnd) {
       let rulelist = this.parseRulelist(tokenizer);
 
@@ -307,27 +314,29 @@ class Parser {
         tokenizer.advance();
       }
 
-      const nameRange = tokenizer.getRange(
-        ruleStart!, ruleEnd.previous);
-      const declarationName = tokenizer.cssText.slice(
-          nameRange.start, nameRange.end);
+      const nameRange = tokenizer.getRange(ruleStart!, ruleEnd.previous);
+      const declarationName =
+          tokenizer.cssText.slice(nameRange.start, nameRange.end);
 
       const range = tokenizer.trimRange(tokenizer.getRange(
           ruleStart!,
-          tokenizer.currentToken && tokenizer.currentToken.previous || ruleEnd));
+          tokenizer.currentToken && tokenizer.currentToken.previous ||
+              ruleEnd));
 
       return this.nodeFactory.declaration(
           declarationName, rulelist, nameRange, range);
-    // Otherwise, this is a ruleset:
+      // Otherwise, this is a ruleset:
     } else {
       const selectorRange = tokenizer.getRange(ruleStart!, ruleEnd);
-      const selector = tokenizer.cssText.slice(
-          selectorRange.start, selectorRange.end);
+      const selector =
+          tokenizer.cssText.slice(selectorRange.start, selectorRange.end);
       const rulelist = this.parseRulelist(tokenizer);
       const start = ruleStart!.start;
       let end;
       if (tokenizer.currentToken) {
-        end = tokenizer.currentToken.previous ? tokenizer.currentToken.previous.end : ruleStart!.end;
+        end = tokenizer.currentToken.previous ?
+            tokenizer.currentToken.previous.end :
+            ruleStart!.end;
       } else {
         // no current token? must have reached the end of input, so go up
         // until there
@@ -339,4 +348,4 @@ class Parser {
   }
 }
 
-export { Parser };
+export {Parser};

--- a/src/shady-css/stringifier.ts
+++ b/src/shady-css/stringifier.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {AtRule, Comment, Declaration, Discarded, Expression, Node, nodeType, Rulelist, Ruleset, Stylesheet} from './common';
@@ -46,8 +47,8 @@ class Stringifier extends NodeVisitor<Node, string> {
    */
   [nodeType.atRule](atRule: AtRule) {
     return `@${atRule.name}` +
-      (atRule.parameters ? ` ${atRule.parameters}` : '') +
-      (atRule.rulelist ? `${this.visit(atRule.rulelist)}` : ';');
+        (atRule.parameters ? ` ${atRule.parameters}` : '') +
+        (atRule.rulelist ? `${this.visit(atRule.rulelist)}` : ';');
   }
 
   /**
@@ -90,8 +91,8 @@ class Stringifier extends NodeVisitor<Node, string> {
    */
   [nodeType.declaration](declaration: Declaration) {
     return declaration.value != null ?
-      `${declaration.name}:${this.visit(declaration.value)};` :
-      `${declaration.name};`;
+        `${declaration.name}:${this.visit(declaration.value)};` :
+        `${declaration.name};`;
   }
 
   /**
@@ -113,4 +114,4 @@ class Stringifier extends NodeVisitor<Node, string> {
   }
 }
 
-export { Stringifier };
+export {Stringifier};

--- a/src/shady-css/token.ts
+++ b/src/shady-css/token.ts
@@ -38,7 +38,7 @@ export enum TokenType {
   hyphen = (2 ** 13),
   underscore = (2 ** 14)
 }
-;
+
 
 /**
  * Class that describes individual tokens as produced by the Tokenizer.

--- a/src/shady-css/token.ts
+++ b/src/shady-css/token.ts
@@ -1,42 +1,44 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 /**
  * An enumeration of Token types.
  */
 export enum TokenType {
-  none =  0,
-  whitespace =  (2 ** 0),
-  string =  (2 ** 1),
-  comment =  (2 ** 2),
-  word =  (2 ** 3),
-  boundary =  (2 ** 4),
-  propertyBoundary =  (2 ** 5),
+  none = 0,
+  whitespace = (2 ** 0),
+  string = (2 ** 1),
+  comment = (2 ** 2),
+  word = (2 ** 3),
+  boundary = (2 ** 4),
+  propertyBoundary = (2 ** 5),
   // Special cases for boundary:
-  openParenthesis =  (2 ** 6) | TokenType.boundary,
-  closeParenthesis =  (2 ** 7) | TokenType.boundary,
-  at =  (2 ** 8) | TokenType.boundary,
-  openBrace =  (2 ** 9) | TokenType.boundary,
+  openParenthesis = (2 ** 6) | TokenType.boundary,
+  closeParenthesis = (2 ** 7) | TokenType.boundary,
+  at = (2 ** 8) | TokenType.boundary,
+  openBrace = (2 ** 9) | TokenType.boundary,
   // [};] are property boundaries:
-  closeBrace =  (2 ** 10) | TokenType.propertyBoundary | TokenType.boundary,
-  semicolon =  (2 ** 11) | TokenType.propertyBoundary | TokenType.boundary,
+  closeBrace = (2 ** 10) | TokenType.propertyBoundary | TokenType.boundary,
+  semicolon = (2 ** 11) | TokenType.propertyBoundary | TokenType.boundary,
   // : is a chimaeric abomination:
   // foo:bar{}
   // foo:bar;
-  colon =  (2 ** 12) | TokenType.boundary | TokenType.word,
+  colon = (2 ** 12) | TokenType.boundary | TokenType.word,
 
   // TODO: are these two boundaries? I mean, sometimes they are I guess? Or
   //       maybe they shouldn't exist in the boundaryTokenTypes map.
   hyphen = (2 ** 13),
   underscore = (2 ** 14)
-};
+}
+;
 
 /**
  * Class that describes individual tokens as produced by the Tokenizer.
@@ -47,8 +49,8 @@ class Token {
   readonly type: TokenType;
   readonly start: number;
   readonly end: number;
-  previous: Token | null;
-  next: Token | null;
+  previous: Token|null;
+  next: Token|null;
 
   /**
    * Create a Token instance.
@@ -81,7 +83,7 @@ class Token {
 /**
  * A mapping of boundary token text to their corresponding types.
  */
-const boundaryTokenTypes: {[boundaryText: string]: TokenType|undefined} = {
+const boundaryTokenTypes: {[boundaryText: string]: TokenType | undefined} = {
   '(': Token.type.openParenthesis,
   ')': Token.type.closeParenthesis,
   ':': Token.type.colon,
@@ -93,4 +95,4 @@ const boundaryTokenTypes: {[boundaryText: string]: TokenType|undefined} = {
   '_': Token.type.underscore
 };
 
-export { Token, boundaryTokenTypes };
+export {Token, boundaryTokenTypes};

--- a/src/shady-css/tokenizer.ts
+++ b/src/shady-css/tokenizer.ts
@@ -113,7 +113,7 @@ class Tokenizer {
    * @return An array of all tokens corresponding to the CSS text.
    */
   flush() {
-    let tokens = [];
+    const tokens = [];
     while (this.currentToken) {
       tokens.push(this.advance());
     }
@@ -126,7 +126,7 @@ class Tokenizer {
    * tokenized.
    */
   private getNextToken_(): Token|null {
-    let character = this.cssText[this.offset];
+    const character = this.cssText[this.offset];
     let token;
 
     this.currentToken_ = null;
@@ -160,9 +160,9 @@ class Tokenizer {
    * @return A string Token instance.
    */
   tokenizeString(offset: number) {
-    let quotation = this.cssText[offset];
+    const quotation = this.cssText[offset];
     let escaped = false;
-    let start = offset;
+    const start = offset;
     let character;
 
     while (character = this.cssText[++offset]) {
@@ -192,7 +192,7 @@ class Tokenizer {
    * @return A word Token instance.
    */
   tokenizeWord(offset: number): Token {
-    let start = offset;
+    const start = offset;
     let character;
     // TODO(cdata): change to greedy regex match?
     while ((character = this.cssText[offset]) &&
@@ -211,10 +211,10 @@ class Tokenizer {
    * @return A whitespace Token instance.
    */
   tokenizeWhitespace(offset: number) {
-    let start = offset;
+    const start = offset;
 
     matcher.whitespaceGreedy.lastIndex = offset;
-    let match = matcher.whitespaceGreedy.exec(this.cssText);
+    const match = matcher.whitespaceGreedy.exec(this.cssText);
 
     if (match != null && match.index === offset) {
       offset = matcher.whitespaceGreedy.lastIndex;
@@ -231,10 +231,10 @@ class Tokenizer {
    * @return A comment Token instance.
    */
   tokenizeComment(offset: number) {
-    let start = offset;
+    const start = offset;
 
     matcher.commentGreedy.lastIndex = offset;
-    let match = matcher.commentGreedy.exec(this.cssText);
+    const match = matcher.commentGreedy.exec(this.cssText);
 
     if (match == null) {
       offset = this.cssText.length;
@@ -254,7 +254,8 @@ class Tokenizer {
    */
   tokenizeBoundary(offset: number): Token {
     // TODO(cdata): Evaluate if this is faster than a switch statement:
-    let type = boundaryTokenTypes[this.cssText[offset]] || Token.type.boundary;
+    const type =
+        boundaryTokenTypes[this.cssText[offset]] || Token.type.boundary;
 
     return new Token(type, offset, offset + 1);
   }

--- a/src/shady-css/tokenizer.ts
+++ b/src/shady-css/tokenizer.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {matcher, Range} from './common';
@@ -93,7 +94,7 @@ class Tokenizer {
    * Like `slice`, but returns the offsets into the source, rather than the
    * substring itself.
    */
-  getRange(startToken: Token, endToken: Token|undefined|null=undefined) {
+  getRange(startToken: Token, endToken: Token|undefined|null = undefined) {
     return {start: startToken.start, end: (endToken || startToken).end};
   }
 
@@ -101,7 +102,7 @@ class Tokenizer {
     while (start <= end && /\s/.test(this.cssText.charAt(start))) {
       start++;
     }
-    while (start <= end && end > 0 && /\s/.test(this.cssText.charAt(end-1))) {
+    while (start <= end && end > 0 && /\s/.test(this.cssText.charAt(end - 1))) {
       end--;
     }
     return {start, end};
@@ -259,4 +260,4 @@ class Tokenizer {
   }
 }
 
-export { Tokenizer };
+export {Tokenizer};

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 // CSS test fixtures:

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {expect} from 'chai';
@@ -46,8 +47,4 @@ function linkedTokens(tokens: Token[]) {
   return tokens;
 }
 
-export {
-  expectTokenType,
-  expectTokenSequence,
-  linkedTokens
-};
+export {expectTokenType, expectTokenSequence, linkedTokens};

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -21,7 +21,7 @@ function expectTokenType(token: Token, type: TokenType) {
 
 function expectTokenSequence(
     lexer: Tokenizer, sequence: Array<TokenType|string>) {
-  let lexedSequence = [];
+  const lexedSequence = [];
   let token;
 
   while (token = lexer.advance()) {

--- a/src/test/node-visitor-test.ts
+++ b/src/test/node-visitor-test.ts
@@ -1,19 +1,26 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import { expect } from 'chai';
-import { NodeVisitor } from '../shady-css/node-visitor';
+import {expect} from 'chai';
+import {NodeVisitor} from '../shady-css/node-visitor';
 
-type TestNode = TestNodeA | TestNodeB;
-interface TestNodeA {type: 'a', callback?: () => void};
-interface TestNodeB {type: 'b', child?: TestNode};
+type TestNode = TestNodeA|TestNodeB;
+interface TestNodeA {
+  type: 'a', callback?: () => void
+}
+;
+interface TestNodeB {
+  type: 'b', child?: TestNode
+}
+;
 class TestNodeVisitor extends NodeVisitor<TestNode, string> {
   aCallCount: number;
   bCallCount: number;
@@ -50,14 +57,10 @@ describe('NodeVisitor', () => {
   });
 
   it('visits nodes based on their type property', () => {
-    nodeVisitor.visit({
-      type: 'a'
-    });
+    nodeVisitor.visit({type: 'a'});
     expect(nodeVisitor.aCallCount).to.be.eql(1);
     expect(nodeVisitor.bCallCount).to.be.eql(0);
-    nodeVisitor.visit({
-      type: 'b'
-    });
+    nodeVisitor.visit({type: 'b'});
     expect(nodeVisitor.aCallCount).to.be.eql(1);
     expect(nodeVisitor.bCallCount).to.be.eql(1);
   });
@@ -75,10 +78,7 @@ describe('NodeVisitor', () => {
         expect(nodeVisitor.path).to.be.eql([b, a2]);
       }
     };
-    let b =  {
-      type: 'b' as 'b',
-      child: a2
-    };
+    let b = {type: 'b' as 'b', child: a2};
 
     nodeVisitor.visit(a1);
     expect(nodeVisitor.aCallCount).to.be.eql(1);

--- a/src/test/node-visitor-test.ts
+++ b/src/test/node-visitor-test.ts
@@ -14,13 +14,15 @@ import {NodeVisitor} from '../shady-css/node-visitor';
 
 type TestNode = TestNodeA|TestNodeB;
 interface TestNodeA {
-  type: 'a', callback?: () => void
+  type: 'a';
+  callback?: () => void;
 }
-;
+
 interface TestNodeB {
-  type: 'b', child?: TestNode
+  type: 'b';
+  child?: TestNode;
 }
-;
+
 class TestNodeVisitor extends NodeVisitor<TestNode, string> {
   aCallCount: number;
   bCallCount: number;
@@ -66,19 +68,19 @@ describe('NodeVisitor', () => {
   });
 
   it('reveals the path of the recursive visitation of nodes', () => {
-    let a1 = {
+    const a1 = {
       type: 'a' as 'a',
       callback: function() {
         expect(nodeVisitor.path).to.be.eql([a1]);
       }
     };
-    let a2: TestNodeA = {
+    const a2: TestNodeA = {
       type: 'a' as 'a',
       callback: function() {
         expect(nodeVisitor.path).to.be.eql([b, a2]);
       }
     };
-    let b = {type: 'b' as 'b', child: a2};
+    const b = {type: 'b' as 'b', child: a2};
 
     nodeVisitor.visit(a1);
     expect(nodeVisitor.aCallCount).to.be.eql(1);

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -68,17 +68,16 @@ describe('Parser', () => {
           ]));
     });
 
-    it('can parse custom properties',
-       () => {
-           expect(parser.parse(fixtures.customProperties))
-               .to.containSubset(nodeFactory.stylesheet(
-                   [nodeFactory.ruleset(':root', nodeFactory.rulelist([
-                     nodeFactory.declaration(
-                         '--qux', nodeFactory.expression('vim')),
-                     nodeFactory.declaration(
-                         '--foo', nodeFactory.rulelist([nodeFactory.declaration(
-                                      'bar', nodeFactory.expression('baz'))]))
-                   ]))]))});
+    it('can parse custom properties', () => {
+      expect(parser.parse(fixtures.customProperties))
+          .to.containSubset(nodeFactory.stylesheet(
+              [nodeFactory.ruleset(':root', nodeFactory.rulelist([
+                nodeFactory.declaration('--qux', nodeFactory.expression('vim')),
+                nodeFactory.declaration(
+                    '--foo', nodeFactory.rulelist([nodeFactory.declaration(
+                                 'bar', nodeFactory.expression('baz'))]))
+              ]))]));
+    });
 
     it('can parse declarations with no value', () => {
       expect(parser.parse(fixtures.declarationsWithNoValue))
@@ -154,7 +153,7 @@ describe('Parser', () => {
     it('extracts the correct ranges for discarded nodes', () => {
       const ast = parser.parse(fixtures.extraSemicolons);
       const nodes = getNodesOfType(ast, 'discarded');
-      const rangeSubStrings = Array.from(nodes).map(n => {
+      const rangeSubStrings = Array.from(nodes).map((n) => {
         return fixtures.extraSemicolons.substring(n.range.start, n.range.end);
       });
       expect(rangeSubStrings).to.be.deep.equal([';;', ';', ';', ';']);
@@ -163,7 +162,7 @@ describe('Parser', () => {
     it('extracts the correct ranges for expression nodes', () => {
       const ast = parser.parse(fixtures.basicRuleset);
       const nodes = getNodesOfType(ast, 'expression');
-      const rangeSubStrings = Array.from(nodes).map(n => {
+      const rangeSubStrings = Array.from(nodes).map((n) => {
         return fixtures.basicRuleset.substring(n.range.start, n.range.end);
       });
       expect(rangeSubStrings).to.be.deep.equal(['0', '0px']);
@@ -176,10 +175,10 @@ describe('Parser', () => {
            expectedNameRangeStrings: string[]) => {
             const ast = parser.parse(cssText);
             const nodes = Array.from(getNodesOfType(ast, 'declaration'));
-            const rangeStrings = nodes.map(n => {
+            const rangeStrings = nodes.map((n) => {
               return cssText.substring(n.range.start, n.range.end);
             });
-            const nameRangeStrings = nodes.map(n => {
+            const nameRangeStrings = nodes.map((n) => {
               return cssText.substring(n.nameRange.start, n.nameRange.end);
             });
 
@@ -190,17 +189,17 @@ describe('Parser', () => {
       expectDeclarationRanges(
           fixtures.basicRuleset,
           ['margin: 0;', 'padding: 0px'],
-          ['margin', 'padding'])
+          ['margin', 'padding']);
       expectDeclarationRanges(
-          fixtures.atRules, ['font-family: foo;'], ['font-family'])
+          fixtures.atRules, ['font-family: foo;'], ['font-family']);
       expectDeclarationRanges(
           fixtures.keyframes,
           ['fiz: 0%;', 'fiz: 100px;', 'buz: true;'],
-          ['fiz', 'fiz', 'buz'])
+          ['fiz', 'fiz', 'buz']);
       expectDeclarationRanges(
           fixtures.customProperties,
           ['--qux: vim;', '--foo: {\n    bar: baz;\n  };', 'bar: baz;'],
-          ['--qux', '--foo', 'bar'])
+          ['--qux', '--foo', 'bar']);
       expectDeclarationRanges(
           fixtures.extraSemicolons,
           [
@@ -208,24 +207,24 @@ describe('Parser', () => {
             'padding: 0;',
             'display: block;',
           ],
-          ['margin', 'padding', 'display'])
+          ['margin', 'padding', 'display']);
       expectDeclarationRanges(
           fixtures.declarationsWithNoValue,
           ['foo;', 'bar 20px;', 'baz;'],
-          ['foo', 'bar 20px', 'baz'])
+          ['foo', 'bar 20px', 'baz']);
       expectDeclarationRanges(
-          fixtures.minifiedRuleset, ['bar:baz', 'vim:fet;'], ['bar', 'vim'])
+          fixtures.minifiedRuleset, ['bar:baz', 'vim:fet;'], ['bar', 'vim']);
       expectDeclarationRanges(
           fixtures.psuedoRuleset,
           ['baz:qux'],
           ['baz'],
-      )
+      );
       expectDeclarationRanges(
-          fixtures.dataUriRuleset, ['bar:url(qux;gib)'], ['bar'])
+          fixtures.dataUriRuleset, ['bar:url(qux;gib)'], ['bar']);
       expectDeclarationRanges(
           fixtures.pathologicalComments,
           ['bar: /*baz*/vim;', 'baz: lur;'],
-          ['bar', 'baz'])
+          ['bar', 'baz']);
     });
 
     it('extracts the correct ranges for rulesets', () => {
@@ -235,10 +234,10 @@ describe('Parser', () => {
            expectedSelectorRangeStrings: string[]) => {
             const ast = parser.parse(cssText);
             const nodes = Array.from(getNodesOfType(ast, 'ruleset'));
-            const rangeStrings = nodes.map(n => {
+            const rangeStrings = nodes.map((n) => {
               return cssText.substring(n.range.start, n.range.end);
             });
-            const selectorRangeStrings = nodes.map(n => {
+            const selectorRangeStrings = nodes.map((n) => {
               return cssText.substring(
                   n.selectorRange.start, n.selectorRange.end);
             });
@@ -251,40 +250,40 @@ describe('Parser', () => {
       expectRulesetRanges(
           fixtures.basicRuleset,
           [`body {\n  margin: 0;\n  padding: 0px\n}`],
-          ['body'])
-      expectRulesetRanges(fixtures.atRules, [], [])
+          ['body']);
+      expectRulesetRanges(fixtures.atRules, [], []);
       expectRulesetRanges(
           fixtures.keyframes,
           [
             'from {\n    fiz: 0%;\n  }',
             '99.9% {\n    fiz: 100px;\n    buz: true;\n  }'
           ],
-          ['from', '99.9%'])
+          ['from', '99.9%']);
       expectRulesetRanges(
           fixtures.customProperties,
           [':root {\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}'],
-          [':root'])
+          [':root']);
       expectRulesetRanges(
           fixtures.extraSemicolons,
           [':host {\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}'],
-          [':host'])
+          [':host']);
       expectRulesetRanges(
-          fixtures.declarationsWithNoValue, ['div {\n  baz;\n}'], ['div'])
+          fixtures.declarationsWithNoValue, ['div {\n  baz;\n}'], ['div']);
       expectRulesetRanges(
           fixtures.minifiedRuleset,
           ['.foo{bar:baz}', 'div .qux{vim:fet;}'],
-          ['.foo', 'div .qux'])
+          ['.foo', 'div .qux']);
       expectRulesetRanges(
           fixtures.psuedoRuleset,
           ['.foo:bar:not(#rif){baz:qux}'],
           ['.foo:bar:not(#rif)'],
-      )
+      );
       expectRulesetRanges(
-          fixtures.dataUriRuleset, ['.foo{bar:url(qux;gib)}'], ['.foo'])
+          fixtures.dataUriRuleset, ['.foo{bar:url(qux;gib)}'], ['.foo']);
       expectRulesetRanges(
           fixtures.pathologicalComments,
           ['.foo {\n  bar: /*baz*/vim;\n}'],
-          ['.foo'])
+          ['.foo']);
     });
 
     it('extracts the correct ranges for rulelists', () => {
@@ -292,7 +291,7 @@ describe('Parser', () => {
           (cssText: string, expectedRangeStrings: string[]) => {
             const ast = parser.parse(cssText);
             const nodes = Array.from(getNodesOfType(ast, 'rulelist'));
-            const rangeStrings = nodes.map(n => {
+            const rangeStrings = nodes.map((n) => {
               return cssText.substring(n.range.start, n.range.end);
             });
 
@@ -300,31 +299,31 @@ describe('Parser', () => {
           };
 
       expectRulelistRanges(
-          fixtures.basicRuleset, [`{\n  margin: 0;\n  padding: 0px\n}`])
+          fixtures.basicRuleset, [`{\n  margin: 0;\n  padding: 0px\n}`]);
       expectRulelistRanges(
           fixtures.atRules,
           ['{\n  font-family: foo;\n}'],
-      )
+      );
       expectRulelistRanges(fixtures.keyframes, [
         '{\n  from {\n    fiz: 0%;\n  }\n\n  99.9% ' +
             '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
         '{\n    fiz: 0%;\n  }',
         '{\n    fiz: 100px;\n    buz: true;\n  }'
-      ])
+      ]);
       expectRulelistRanges(fixtures.customProperties, [
         '{\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}',
         '{\n    bar: baz;\n  }'
-      ])
+      ]);
       expectRulelistRanges(
           fixtures.extraSemicolons,
-          ['{\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}'])
-      expectRulelistRanges(fixtures.declarationsWithNoValue, ['{\n  baz;\n}'])
+          ['{\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}']);
+      expectRulelistRanges(fixtures.declarationsWithNoValue, ['{\n  baz;\n}']);
       expectRulelistRanges(
-          fixtures.minifiedRuleset, ['{bar:baz}', '{vim:fet;}'])
-      expectRulelistRanges(fixtures.psuedoRuleset, ['{baz:qux}'])
-      expectRulelistRanges(fixtures.dataUriRuleset, ['{bar:url(qux;gib)}'])
+          fixtures.minifiedRuleset, ['{bar:baz}', '{vim:fet;}']);
+      expectRulelistRanges(fixtures.psuedoRuleset, ['{baz:qux}']);
+      expectRulelistRanges(fixtures.dataUriRuleset, ['{bar:url(qux;gib)}']);
       expectRulelistRanges(
-          fixtures.pathologicalComments, ['{\n  bar: /*baz*/vim;\n}'])
+          fixtures.pathologicalComments, ['{\n  bar: /*baz*/vim;\n}']);
     });
 
     it('extracts the correct ranges for atRules', () => {
@@ -335,13 +334,13 @@ describe('Parser', () => {
            expectedParameterRangeStrings: string[]) => {
             const ast = parser.parse(cssText);
             const nodes = Array.from(getNodesOfType(ast, 'atRule'));
-            const rangeStrings = nodes.map(n => {
+            const rangeStrings = nodes.map((n) => {
               return cssText.substring(n.range.start, n.range.end);
             });
-            const rangeNameStrings = nodes.map(n => {
+            const rangeNameStrings = nodes.map((n) => {
               return cssText.substring(n.nameRange.start, n.nameRange.end);
             });
-            const rangeParametersStrings = nodes.map(n => {
+            const rangeParametersStrings = nodes.map((n) => {
               if (!n.parametersRange) {
                 return '[no parameters]';
               }
@@ -357,7 +356,7 @@ describe('Parser', () => {
                 .to.be.deep.equal(expectedParameterRangeStrings);
           };
 
-      expectAtRuleRanges(fixtures.basicRuleset, [], [], [])
+      expectAtRuleRanges(fixtures.basicRuleset, [], [], []);
       expectAtRuleRanges(
           fixtures.atRules,
           [
@@ -366,7 +365,7 @@ describe('Parser', () => {
             `@charset 'foo';`
           ],
           ['import', 'font-face', 'charset'],
-          [`url('foo.css')`, `[no parameters]`, `'foo'`])
+          [`url('foo.css')`, `[no parameters]`, `'foo'`]);
       expectAtRuleRanges(
           fixtures.keyframes,
           [
@@ -374,15 +373,15 @@ describe('Parser', () => {
                 '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
           ],
           ['keyframes'],
-          ['foo'])
-      expectAtRuleRanges(fixtures.customProperties, [], [], [])
-      expectAtRuleRanges(fixtures.extraSemicolons, [], [], [])
-      expectAtRuleRanges(fixtures.declarationsWithNoValue, [], [], [])
-      expectAtRuleRanges(fixtures.minifiedRuleset, [], [], [])
-      expectAtRuleRanges(fixtures.psuedoRuleset, [], [], [])
-      expectAtRuleRanges(fixtures.dataUriRuleset, [], [], [])
+          ['foo']);
+      expectAtRuleRanges(fixtures.customProperties, [], [], []);
+      expectAtRuleRanges(fixtures.extraSemicolons, [], [], []);
+      expectAtRuleRanges(fixtures.declarationsWithNoValue, [], [], []);
+      expectAtRuleRanges(fixtures.minifiedRuleset, [], [], []);
+      expectAtRuleRanges(fixtures.psuedoRuleset, [], [], []);
+      expectAtRuleRanges(fixtures.dataUriRuleset, [], [], []);
       expectAtRuleRanges(
-          fixtures.pathologicalComments, ['@gak wiz;'], ['gak'], ['wiz'])
+          fixtures.pathologicalComments, ['@gak wiz;'], ['gak'], ['wiz']);
     });
   });
 });
@@ -402,7 +401,7 @@ function* iterAst(node: Node): Iterable<Node> {
   switch (node.type) {
     case nodeType.stylesheet:
       for (const rule of node.rules) {
-        yield* iterAst(rule)
+        yield* iterAst(rule);
       }
       return;
     case nodeType.ruleset:

--- a/src/test/parser-test.ts
+++ b/src/test/parser-test.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {expect, use} from 'chai';
@@ -33,121 +34,119 @@ describe('Parser', () => {
     it('can parse a basic ruleset', () => {
       expect(parser.parse(fixtures.basicRuleset))
           .to.be.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset('body', nodeFactory.rulelist([
-          nodeFactory.declaration('margin', nodeFactory.expression('0')),
-          nodeFactory.declaration('padding', nodeFactory.expression('0px'))
-        ]))
-      ]));
+            nodeFactory.ruleset('body', nodeFactory.rulelist([
+              nodeFactory.declaration('margin', nodeFactory.expression('0')),
+              nodeFactory.declaration('padding', nodeFactory.expression('0px'))
+            ]))
+          ]));
     });
 
     it('can parse at rules', () => {
-      expect(parser.parse(fixtures.atRules)).to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.atRule('import', 'url(\'foo.css\')', undefined),
-        nodeFactory.atRule('font-face', '', nodeFactory.rulelist([
-          nodeFactory.declaration(
-            'font-family',
-            nodeFactory.expression('foo')
-          )
-        ])),
-        nodeFactory.atRule('charset', '\'foo\'', undefined)
-      ]));
+      expect(parser.parse(fixtures.atRules))
+          .to.containSubset(nodeFactory.stylesheet([
+            nodeFactory.atRule('import', 'url(\'foo.css\')', undefined),
+            nodeFactory.atRule(
+                'font-face', '', nodeFactory.rulelist([nodeFactory.declaration(
+                                     'font-family',
+                                     nodeFactory.expression('foo'))])),
+            nodeFactory.atRule('charset', '\'foo\'', undefined)
+          ]));
     });
 
     it('can parse keyframes', () => {
       expect(parser.parse(fixtures.keyframes))
           .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.atRule('keyframes', 'foo', nodeFactory.rulelist([
-          nodeFactory.ruleset('from', nodeFactory.rulelist([
-            nodeFactory.declaration('fiz', nodeFactory.expression('0%'))
-          ])),
-          nodeFactory.ruleset('99.9%', nodeFactory.rulelist([
-            nodeFactory.declaration('fiz', nodeFactory.expression('100px')),
-            nodeFactory.declaration('buz',nodeFactory.expression('true'))
-          ]))
-        ]))
-      ]));
+            nodeFactory.atRule('keyframes', 'foo', nodeFactory.rulelist([
+              nodeFactory.ruleset(
+                  'from', nodeFactory.rulelist([nodeFactory.declaration(
+                              'fiz', nodeFactory.expression('0%'))])),
+              nodeFactory.ruleset('99.9%', nodeFactory.rulelist([
+                nodeFactory.declaration('fiz', nodeFactory.expression('100px')),
+                nodeFactory.declaration('buz', nodeFactory.expression('true'))
+              ]))
+            ]))
+          ]));
     });
 
-    it('can parse custom properties', () => {
-      expect(parser.parse(fixtures.customProperties))
-          .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset(':root', nodeFactory.rulelist([
-          nodeFactory.declaration('--qux', nodeFactory.expression('vim')),
-          nodeFactory.declaration('--foo', nodeFactory.rulelist([
-             nodeFactory.declaration('bar', nodeFactory.expression('baz'))
-          ]))
-        ]))
-      ]))
-    });
+    it('can parse custom properties',
+       () => {
+           expect(parser.parse(fixtures.customProperties))
+               .to.containSubset(nodeFactory.stylesheet(
+                   [nodeFactory.ruleset(':root', nodeFactory.rulelist([
+                     nodeFactory.declaration(
+                         '--qux', nodeFactory.expression('vim')),
+                     nodeFactory.declaration(
+                         '--foo', nodeFactory.rulelist([nodeFactory.declaration(
+                                      'bar', nodeFactory.expression('baz'))]))
+                   ]))]))});
 
     it('can parse declarations with no value', () => {
       expect(parser.parse(fixtures.declarationsWithNoValue))
           .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.declaration('foo', undefined),
-        nodeFactory.declaration('bar 20px', undefined),
-        nodeFactory.ruleset('div', nodeFactory.rulelist([
-          nodeFactory.declaration('baz', undefined)
-        ]))
-      ]));
+            nodeFactory.declaration('foo', undefined),
+            nodeFactory.declaration('bar 20px', undefined),
+            nodeFactory.ruleset(
+                'div', nodeFactory.rulelist([nodeFactory.declaration(
+                           'baz', undefined)]))
+          ]));
     });
 
     it('can parse minified rulelists', () => {
       expect(parser.parse(fixtures.minifiedRuleset))
           .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset('.foo', nodeFactory.rulelist([
-          nodeFactory.declaration('bar', nodeFactory.expression('baz'))
-        ])),
-        nodeFactory.ruleset('div .qux', nodeFactory.rulelist([
-          nodeFactory.declaration('vim', nodeFactory.expression('fet'))
-        ]))
-      ]));
+            nodeFactory.ruleset(
+                '.foo', nodeFactory.rulelist([nodeFactory.declaration(
+                            'bar', nodeFactory.expression('baz'))])),
+            nodeFactory.ruleset(
+                'div .qux', nodeFactory.rulelist([nodeFactory.declaration(
+                                'vim', nodeFactory.expression('fet'))]))
+          ]));
     });
 
     it('can parse psuedo rulesets', () => {
       expect(parser.parse(fixtures.psuedoRuleset))
-          .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset('.foo:bar:not(#rif)', nodeFactory.rulelist([
-          nodeFactory.declaration('baz', nodeFactory.expression('qux'))
-        ]))
-      ]));
+          .to.containSubset(nodeFactory.stylesheet([nodeFactory.ruleset(
+              '.foo:bar:not(#rif)',
+              nodeFactory.rulelist([nodeFactory.declaration(
+                  'baz', nodeFactory.expression('qux'))]))]));
     });
 
     it('can parse rulelists with data URIs', () => {
       expect(parser.parse(fixtures.dataUriRuleset))
-          .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset('.foo', nodeFactory.rulelist([
-          nodeFactory.declaration('bar', nodeFactory.expression('url(qux;gib)'))
-        ]))
-      ]));
+          .to.containSubset(nodeFactory.stylesheet([nodeFactory.ruleset(
+              '.foo', nodeFactory.rulelist([nodeFactory.declaration(
+                          'bar', nodeFactory.expression('url(qux;gib)'))]))]));
     });
 
     it('can parse pathological comments', () => {
       expect(parser.parse(fixtures.pathologicalComments))
           .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset('.foo', nodeFactory.rulelist([
-          nodeFactory.declaration('bar', nodeFactory.expression('/*baz*/vim'))
-        ])),
-        nodeFactory.comment('/* unclosed\n@fiz {\n  --huk: {\n    /* buz */'),
-        nodeFactory.declaration('baz', nodeFactory.expression('lur')),
-        nodeFactory.discarded('};'),
-        nodeFactory.discarded('}'),
-        nodeFactory.atRule('gak', 'wiz', undefined)
-      ]));
+            nodeFactory.ruleset(
+                '.foo', nodeFactory.rulelist([nodeFactory.declaration(
+                            'bar', nodeFactory.expression('/*baz*/vim'))])),
+            nodeFactory.comment(
+                '/* unclosed\n@fiz {\n  --huk: {\n    /* buz */'),
+            nodeFactory.declaration('baz', nodeFactory.expression('lur')),
+            nodeFactory.discarded('};'),
+            nodeFactory.discarded('}'),
+            nodeFactory.atRule('gak', 'wiz', undefined)
+          ]));
     });
 
     it('disregards extra semi-colons', () => {
       expect(parser.parse(fixtures.extraSemicolons))
           .to.containSubset(nodeFactory.stylesheet([
-        nodeFactory.ruleset(':host', nodeFactory.rulelist([
-          nodeFactory.declaration('margin', nodeFactory.expression('0')),
-          nodeFactory.discarded(';;'),
-          nodeFactory.declaration('padding', nodeFactory.expression('0')),
-          nodeFactory.discarded(';'),
-          nodeFactory.discarded(';'),
-          nodeFactory.declaration('display', nodeFactory.expression('block')),
-        ])),
-        nodeFactory.discarded(';')
-      ]));
+            nodeFactory.ruleset(':host', nodeFactory.rulelist([
+              nodeFactory.declaration('margin', nodeFactory.expression('0')),
+              nodeFactory.discarded(';;'),
+              nodeFactory.declaration('padding', nodeFactory.expression('0')),
+              nodeFactory.discarded(';'),
+              nodeFactory.discarded(';'),
+              nodeFactory.declaration(
+                  'display', nodeFactory.expression('block')),
+            ])),
+            nodeFactory.discarded(';')
+          ]));
     });
   });
 
@@ -171,264 +170,211 @@ describe('Parser', () => {
     });
 
     it('extracts the correct ranges for declarations', () => {
-      const expectDeclarationRanges = (
-            cssText: string,
-            expectedRangeStrings: string[],
-            expectedNameRangeStrings: string[]) => {
-        const ast = parser.parse(cssText);
-        const nodes = Array.from(getNodesOfType(ast, 'declaration'));
-        const rangeStrings = nodes.map(n => {
-          return cssText.substring(n.range.start, n.range.end);
-        });
-        const nameRangeStrings = nodes.map(n => {
-          return cssText.substring(n.nameRange.start, n.nameRange.end);
-        });
+      const expectDeclarationRanges =
+          (cssText: string,
+           expectedRangeStrings: string[],
+           expectedNameRangeStrings: string[]) => {
+            const ast = parser.parse(cssText);
+            const nodes = Array.from(getNodesOfType(ast, 'declaration'));
+            const rangeStrings = nodes.map(n => {
+              return cssText.substring(n.range.start, n.range.end);
+            });
+            const nameRangeStrings = nodes.map(n => {
+              return cssText.substring(n.nameRange.start, n.nameRange.end);
+            });
 
-        expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
-        expect(nameRangeStrings).to.be.deep.equal(expectedNameRangeStrings);
-      };
+            expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
+            expect(nameRangeStrings).to.be.deep.equal(expectedNameRangeStrings);
+          };
 
       expectDeclarationRanges(
-        fixtures.basicRuleset,
-        ['margin: 0;', 'padding: 0px'],
-        ['margin', 'padding']
+          fixtures.basicRuleset,
+          ['margin: 0;', 'padding: 0px'],
+          ['margin', 'padding'])
+      expectDeclarationRanges(
+          fixtures.atRules, ['font-family: foo;'], ['font-family'])
+      expectDeclarationRanges(
+          fixtures.keyframes,
+          ['fiz: 0%;', 'fiz: 100px;', 'buz: true;'],
+          ['fiz', 'fiz', 'buz'])
+      expectDeclarationRanges(
+          fixtures.customProperties,
+          ['--qux: vim;', '--foo: {\n    bar: baz;\n  };', 'bar: baz;'],
+          ['--qux', '--foo', 'bar'])
+      expectDeclarationRanges(
+          fixtures.extraSemicolons,
+          [
+            'margin: 0;',
+            'padding: 0;',
+            'display: block;',
+          ],
+          ['margin', 'padding', 'display'])
+      expectDeclarationRanges(
+          fixtures.declarationsWithNoValue,
+          ['foo;', 'bar 20px;', 'baz;'],
+          ['foo', 'bar 20px', 'baz'])
+      expectDeclarationRanges(
+          fixtures.minifiedRuleset, ['bar:baz', 'vim:fet;'], ['bar', 'vim'])
+      expectDeclarationRanges(
+          fixtures.psuedoRuleset,
+          ['baz:qux'],
+          ['baz'],
       )
       expectDeclarationRanges(
-        fixtures.atRules,
-        ['font-family: foo;'],
-        ['font-family']
-      )
+          fixtures.dataUriRuleset, ['bar:url(qux;gib)'], ['bar'])
       expectDeclarationRanges(
-        fixtures.keyframes,
-        ['fiz: 0%;', 'fiz: 100px;', 'buz: true;'],
-        ['fiz', 'fiz', 'buz']
-      )
-      expectDeclarationRanges(
-        fixtures.customProperties,
-        [
-          '--qux: vim;',
-          '--foo: {\n    bar: baz;\n  };',
-          'bar: baz;'],
-        ['--qux', '--foo', 'bar']
-      )
-      expectDeclarationRanges(
-        fixtures.extraSemicolons,
-        [
-          'margin: 0;',
-          'padding: 0;',
-          'display: block;',
-        ],
-        ['margin', 'padding', 'display']
-      )
-      expectDeclarationRanges(
-        fixtures.declarationsWithNoValue,
-        ['foo;', 'bar 20px;', 'baz;'],
-        ['foo', 'bar 20px', 'baz']
-      )
-      expectDeclarationRanges(
-        fixtures.minifiedRuleset,
-        ['bar:baz', 'vim:fet;'],
-        ['bar', 'vim']
-      )
-      expectDeclarationRanges(
-        fixtures.psuedoRuleset,
-        ['baz:qux'],
-        ['baz'],
-      )
-      expectDeclarationRanges(
-        fixtures.dataUriRuleset,
-        ['bar:url(qux;gib)'],
-        ['bar']
-      )
-      expectDeclarationRanges(
-        fixtures.pathologicalComments,
-        ['bar: /*baz*/vim;', 'baz: lur;'],
-        ['bar', 'baz']
-      )
+          fixtures.pathologicalComments,
+          ['bar: /*baz*/vim;', 'baz: lur;'],
+          ['bar', 'baz'])
     });
 
     it('extracts the correct ranges for rulesets', () => {
-      const expectRulesetRanges = (
-            cssText: string,
-            expectedRangeStrings: string[],
-            expectedSelectorRangeStrings: string[]) => {
-        const ast = parser.parse(cssText);
-        const nodes = Array.from(getNodesOfType(ast, 'ruleset'));
-        const rangeStrings = nodes.map(n => {
-          return cssText.substring(n.range.start, n.range.end);
-        });
-        const selectorRangeStrings = nodes.map(n => {
-          return cssText.substring(n.selectorRange.start, n.selectorRange.end);
-        });
+      const expectRulesetRanges =
+          (cssText: string,
+           expectedRangeStrings: string[],
+           expectedSelectorRangeStrings: string[]) => {
+            const ast = parser.parse(cssText);
+            const nodes = Array.from(getNodesOfType(ast, 'ruleset'));
+            const rangeStrings = nodes.map(n => {
+              return cssText.substring(n.range.start, n.range.end);
+            });
+            const selectorRangeStrings = nodes.map(n => {
+              return cssText.substring(
+                  n.selectorRange.start, n.selectorRange.end);
+            });
 
-        expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
-        expect(selectorRangeStrings).to.be.deep.equal(expectedSelectorRangeStrings);
-      };
+            expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
+            expect(selectorRangeStrings)
+                .to.be.deep.equal(expectedSelectorRangeStrings);
+          };
 
       expectRulesetRanges(
-        fixtures.basicRuleset,
-        [`body {\n  margin: 0;\n  padding: 0px\n}`],
-        ['body']
+          fixtures.basicRuleset,
+          [`body {\n  margin: 0;\n  padding: 0px\n}`],
+          ['body'])
+      expectRulesetRanges(fixtures.atRules, [], [])
+      expectRulesetRanges(
+          fixtures.keyframes,
+          [
+            'from {\n    fiz: 0%;\n  }',
+            '99.9% {\n    fiz: 100px;\n    buz: true;\n  }'
+          ],
+          ['from', '99.9%'])
+      expectRulesetRanges(
+          fixtures.customProperties,
+          [':root {\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}'],
+          [':root'])
+      expectRulesetRanges(
+          fixtures.extraSemicolons,
+          [':host {\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}'],
+          [':host'])
+      expectRulesetRanges(
+          fixtures.declarationsWithNoValue, ['div {\n  baz;\n}'], ['div'])
+      expectRulesetRanges(
+          fixtures.minifiedRuleset,
+          ['.foo{bar:baz}', 'div .qux{vim:fet;}'],
+          ['.foo', 'div .qux'])
+      expectRulesetRanges(
+          fixtures.psuedoRuleset,
+          ['.foo:bar:not(#rif){baz:qux}'],
+          ['.foo:bar:not(#rif)'],
       )
       expectRulesetRanges(
-        fixtures.atRules,
-        [],
-        []
-      )
+          fixtures.dataUriRuleset, ['.foo{bar:url(qux;gib)}'], ['.foo'])
       expectRulesetRanges(
-        fixtures.keyframes,
-        [
-          'from {\n    fiz: 0%;\n  }',
-          '99.9% {\n    fiz: 100px;\n    buz: true;\n  }'
-        ],
-        ['from', '99.9%']
-      )
-      expectRulesetRanges(
-        fixtures.customProperties,
-        [':root {\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}'],
-        [':root']
-      )
-      expectRulesetRanges(
-        fixtures.extraSemicolons,
-        [':host {\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}'],
-        [':host']
-      )
-      expectRulesetRanges(
-        fixtures.declarationsWithNoValue,
-        ['div {\n  baz;\n}'],
-        ['div']
-      )
-      expectRulesetRanges(
-        fixtures.minifiedRuleset,
-        ['.foo{bar:baz}','div .qux{vim:fet;}'],
-        ['.foo', 'div .qux']
-      )
-      expectRulesetRanges(
-        fixtures.psuedoRuleset,
-        ['.foo:bar:not(#rif){baz:qux}'],
-        ['.foo:bar:not(#rif)'],
-      )
-      expectRulesetRanges(
-        fixtures.dataUriRuleset,
-        ['.foo{bar:url(qux;gib)}'],
-        ['.foo']
-      )
-      expectRulesetRanges(
-        fixtures.pathologicalComments,
-        ['.foo {\n  bar: /*baz*/vim;\n}'],
-        ['.foo']
-      )
+          fixtures.pathologicalComments,
+          ['.foo {\n  bar: /*baz*/vim;\n}'],
+          ['.foo'])
     });
 
     it('extracts the correct ranges for rulelists', () => {
-      const expectRulelistRanges = (
-            cssText: string,
-            expectedRangeStrings: string[]) => {
-        const ast = parser.parse(cssText);
-        const nodes = Array.from(getNodesOfType(ast, 'rulelist'));
-        const rangeStrings = nodes.map(n => {
-          return cssText.substring(n.range.start, n.range.end);
-        });
+      const expectRulelistRanges =
+          (cssText: string, expectedRangeStrings: string[]) => {
+            const ast = parser.parse(cssText);
+            const nodes = Array.from(getNodesOfType(ast, 'rulelist'));
+            const rangeStrings = nodes.map(n => {
+              return cssText.substring(n.range.start, n.range.end);
+            });
 
-        expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
-      };
+            expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
+          };
 
       expectRulelistRanges(
-        fixtures.basicRuleset,
-        [`{\n  margin: 0;\n  padding: 0px\n}`]
-      )
+          fixtures.basicRuleset, [`{\n  margin: 0;\n  padding: 0px\n}`])
       expectRulelistRanges(
-        fixtures.atRules,
-        ['{\n  font-family: foo;\n}'],
+          fixtures.atRules,
+          ['{\n  font-family: foo;\n}'],
       )
+      expectRulelistRanges(fixtures.keyframes, [
+        '{\n  from {\n    fiz: 0%;\n  }\n\n  99.9% ' +
+            '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
+        '{\n    fiz: 0%;\n  }',
+        '{\n    fiz: 100px;\n    buz: true;\n  }'
+      ])
+      expectRulelistRanges(fixtures.customProperties, [
+        '{\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}',
+        '{\n    bar: baz;\n  }'
+      ])
       expectRulelistRanges(
-        fixtures.keyframes,
-        [
-          '{\n  from {\n    fiz: 0%;\n  }\n\n  99.9% ' +
-              '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
-          '{\n    fiz: 0%;\n  }',
-          '{\n    fiz: 100px;\n    buz: true;\n  }'
-        ]
-      )
+          fixtures.extraSemicolons,
+          ['{\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}'])
+      expectRulelistRanges(fixtures.declarationsWithNoValue, ['{\n  baz;\n}'])
       expectRulelistRanges(
-        fixtures.customProperties,
-        [
-          '{\n  --qux: vim;\n  --foo: {\n    bar: baz;\n  };\n}',
-          '{\n    bar: baz;\n  }'
-        ]
-      )
+          fixtures.minifiedRuleset, ['{bar:baz}', '{vim:fet;}'])
+      expectRulelistRanges(fixtures.psuedoRuleset, ['{baz:qux}'])
+      expectRulelistRanges(fixtures.dataUriRuleset, ['{bar:url(qux;gib)}'])
       expectRulelistRanges(
-        fixtures.extraSemicolons,
-        ['{\n  margin: 0;;;\n  padding: 0;;\n  ;display: block;\n}']
-      )
-      expectRulelistRanges(
-        fixtures.declarationsWithNoValue,
-        ['{\n  baz;\n}']
-      )
-      expectRulelistRanges(
-        fixtures.minifiedRuleset,
-        ['{bar:baz}','{vim:fet;}']
-      )
-      expectRulelistRanges(
-        fixtures.psuedoRuleset,
-        ['{baz:qux}']
-      )
-      expectRulelistRanges(
-        fixtures.dataUriRuleset,
-        ['{bar:url(qux;gib)}']
-      )
-      expectRulelistRanges(
-        fixtures.pathologicalComments,
-        ['{\n  bar: /*baz*/vim;\n}']
-      )
+          fixtures.pathologicalComments, ['{\n  bar: /*baz*/vim;\n}'])
     });
 
     it('extracts the correct ranges for atRules', () => {
-      const expectAtRuleRanges = (
-            cssText: string,
-            expectedRangeStrings: string[],
-            expectedNameRangeStrings: string[],
-            expectedParameterRangeStrings: string[]) => {
-        const ast = parser.parse(cssText);
-        const nodes = Array.from(getNodesOfType(ast, 'atRule'));
-        const rangeStrings = nodes.map(n => {
-          return cssText.substring(n.range.start, n.range.end);
-        });
-        const rangeNameStrings = nodes.map(n => {
-          return cssText.substring(n.nameRange.start, n.nameRange.end);
-        });
-        const rangeParametersStrings = nodes.map(n => {
-          if (!n.parametersRange) {
-            return '[no parameters]';
-          }
-          return cssText.substring(n.parametersRange.start, n.parametersRange.end);
-        });
+      const expectAtRuleRanges =
+          (cssText: string,
+           expectedRangeStrings: string[],
+           expectedNameRangeStrings: string[],
+           expectedParameterRangeStrings: string[]) => {
+            const ast = parser.parse(cssText);
+            const nodes = Array.from(getNodesOfType(ast, 'atRule'));
+            const rangeStrings = nodes.map(n => {
+              return cssText.substring(n.range.start, n.range.end);
+            });
+            const rangeNameStrings = nodes.map(n => {
+              return cssText.substring(n.nameRange.start, n.nameRange.end);
+            });
+            const rangeParametersStrings = nodes.map(n => {
+              if (!n.parametersRange) {
+                return '[no parameters]';
+              }
+              return cssText.substring(
+                  n.parametersRange.start, n.parametersRange.end);
+            });
 
 
-        expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
-        expect(rangeNameStrings).to.be.deep.equal(expectedNameRangeStrings);
+            expect(rangeStrings).to.be.deep.equal(expectedRangeStrings);
+            expect(rangeNameStrings).to.be.deep.equal(expectedNameRangeStrings);
 
-        expect(rangeParametersStrings).to.be.deep.equal(expectedParameterRangeStrings);
-      };
+            expect(rangeParametersStrings)
+                .to.be.deep.equal(expectedParameterRangeStrings);
+          };
 
       expectAtRuleRanges(fixtures.basicRuleset, [], [], [])
       expectAtRuleRanges(
-        fixtures.atRules,
-        [
-          `@import url('foo.css');`, `@font-face {\n  font-family: foo;\n}`,
-          `@charset 'foo';`
-        ],
-        ['import', 'font-face', 'charset'],
-        [`url('foo.css')`, `[no parameters]`, `'foo'`]
-      )
+          fixtures.atRules,
+          [
+            `@import url('foo.css');`,
+            `@font-face {\n  font-family: foo;\n}`,
+            `@charset 'foo';`
+          ],
+          ['import', 'font-face', 'charset'],
+          [`url('foo.css')`, `[no parameters]`, `'foo'`])
       expectAtRuleRanges(
-        fixtures.keyframes,
-        [
-          '@keyframes foo {\n  from {\n    fiz: 0%;\n  }\n\n  99.9% ' +
-          '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
-        ],
-        ['keyframes'], ['foo']
-      )
+          fixtures.keyframes,
+          [
+            '@keyframes foo {\n  from {\n    fiz: 0%;\n  }\n\n  99.9% ' +
+                '{\n    fiz: 100px;\n    buz: true;\n  }\n}',
+          ],
+          ['keyframes'],
+          ['foo'])
       expectAtRuleRanges(fixtures.customProperties, [], [], [])
       expectAtRuleRanges(fixtures.extraSemicolons, [], [], [])
       expectAtRuleRanges(fixtures.declarationsWithNoValue, [], [], [])
@@ -436,16 +382,14 @@ describe('Parser', () => {
       expectAtRuleRanges(fixtures.psuedoRuleset, [], [], [])
       expectAtRuleRanges(fixtures.dataUriRuleset, [], [], [])
       expectAtRuleRanges(
-        fixtures.pathologicalComments,
-        ['@gak wiz;'],
-        ['gak'],
-        ['wiz']
-      )
+          fixtures.pathologicalComments, ['@gak wiz;'], ['gak'], ['wiz'])
     });
   });
 });
 
-function *getNodesOfType<K extends keyof NodeTypeMap>(node: Node, type: K): Iterable<NodeTypeMap[K]> {
+function*
+    getNodesOfType<K extends keyof NodeTypeMap>(node: Node, type: K):
+        Iterable<NodeTypeMap[K]> {
   for (const n of iterAst(node)) {
     if (n.type === type as any as nodeType) {
       yield n;
@@ -453,7 +397,7 @@ function *getNodesOfType<K extends keyof NodeTypeMap>(node: Node, type: K): Iter
   }
 }
 
-function *iterAst(node: Node): Iterable<Node> {
+function* iterAst(node: Node): Iterable<Node> {
   yield node;
   switch (node.type) {
     case nodeType.stylesheet:
@@ -481,7 +425,7 @@ function *iterAst(node: Node): Iterable<Node> {
     case nodeType.expression:
     case nodeType.comment:
     case nodeType.discarded:
-      return; // no child nodes
+      return;  // no child nodes
     default:
       const never: never = node;
       console.error(`Got a node of unknown type: ${util.inspect(never)}`);

--- a/src/test/stringifier-test.ts
+++ b/src/test/stringifier-test.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 import {expect} from 'chai';
@@ -99,15 +100,15 @@ describe('Stringifier', () => {
     });
 
     it('can stringify custom properties', () => {
-      let cssText = stringifier.stringify(
-          parser.parse(fixtures.customProperties));
+      let cssText =
+          stringifier.stringify(parser.parse(fixtures.customProperties));
       expect(cssText).to.be.eql(':root{--qux:vim;--foo:{bar:baz;};}');
     });
 
     describe('with discarded nodes', () => {
       it('stringifies to a corrected stylesheet', () => {
-        let cssText = stringifier.stringify(
-            parser.parse(fixtures.pathologicalComments));
+        let cssText =
+            stringifier.stringify(parser.parse(fixtures.pathologicalComments));
         expect(cssText).to.be.eql(
             '.foo{bar:/*baz*/vim;}/* unclosed\n@fiz {\n  --huk: {\n    /* buz */baz:lur;@gak wiz;');
       });

--- a/src/test/stringifier-test.ts
+++ b/src/test/stringifier-test.ts
@@ -28,42 +28,43 @@ describe('Stringifier', () => {
 
   describe('when stringifying CSS nodes', () => {
     it('can stringify an empty Stylesheet', () => {
-      let cssText = stringifier.stringify(nodeFactory.stylesheet([]));
+      const cssText = stringifier.stringify(nodeFactory.stylesheet([]));
       expect(cssText).to.be.eql('');
     });
 
     it('can stringify an At Rule without a Rulelist', () => {
-      let cssText = stringifier.stringify(nodeFactory.atRule('foo', '("bar")'));
+      const cssText =
+          stringifier.stringify(nodeFactory.atRule('foo', '("bar")'));
 
       expect(cssText).to.be.eql('@foo ("bar");');
     });
 
     it('can stringify an At Rule with a Rulelist', () => {
-      let cssText = stringifier.stringify(
+      const cssText = stringifier.stringify(
           nodeFactory.atRule('foo', '("bar")', nodeFactory.rulelist([])));
 
       expect(cssText).to.be.eql('@foo ("bar"){}');
     });
 
     it('can stringify Comments', () => {
-      let cssText = stringifier.stringify(nodeFactory.comment('/* hi */'));
+      const cssText = stringifier.stringify(nodeFactory.comment('/* hi */'));
       expect(cssText).to.be.eql('/* hi */');
     });
 
     it('can stringify Rulesets', () => {
-      let cssText = stringifier.stringify(
+      const cssText = stringifier.stringify(
           nodeFactory.ruleset('.fiz #buz', nodeFactory.rulelist([])));
       expect(cssText).to.be.eql('.fiz #buz{}');
     });
 
     it('can stringify Declarations with Expression values', () => {
-      let cssText = stringifier.stringify(
+      const cssText = stringifier.stringify(
           nodeFactory.declaration('color', nodeFactory.expression('red')));
       expect(cssText).to.be.eql('color:red;');
     });
 
     it('can stringify Declarations with Rulelist values', () => {
-      let cssText = stringifier.stringify(
+      const cssText = stringifier.stringify(
           nodeFactory.declaration('--mixin', nodeFactory.rulelist([])));
       expect(cssText).to.be.eql('--mixin:{};');
     });
@@ -77,37 +78,38 @@ describe('Stringifier', () => {
     });
 
     it('can stringify a basic ruleset', () => {
-      let cssText = stringifier.stringify(parser.parse(fixtures.basicRuleset));
+      const cssText =
+          stringifier.stringify(parser.parse(fixtures.basicRuleset));
       expect(cssText).to.be.eql('body{margin:0;padding:0px;}');
     });
 
     it('can stringify at rules', () => {
-      let cssText = stringifier.stringify(parser.parse(fixtures.atRules));
+      const cssText = stringifier.stringify(parser.parse(fixtures.atRules));
       expect(cssText).to.be.eql(
           '@import url(\'foo.css\');@font-face{font-family:foo;}@charset \'foo\';');
     });
 
     it('can stringify keyframes', () => {
-      let cssText = stringifier.stringify(parser.parse(fixtures.keyframes));
+      const cssText = stringifier.stringify(parser.parse(fixtures.keyframes));
       expect(cssText).to.be.eql(
           '@keyframes foo{from{fiz:0%;}99.9%{fiz:100px;buz:true;}}');
     });
 
     it('can stringify declarations without value', () => {
-      let cssText =
+      const cssText =
           stringifier.stringify(parser.parse(fixtures.declarationsWithNoValue));
       expect(cssText).to.be.eql('foo;bar 20px;div{baz;}');
     });
 
     it('can stringify custom properties', () => {
-      let cssText =
+      const cssText =
           stringifier.stringify(parser.parse(fixtures.customProperties));
       expect(cssText).to.be.eql(':root{--qux:vim;--foo:{bar:baz;};}');
     });
 
     describe('with discarded nodes', () => {
       it('stringifies to a corrected stylesheet', () => {
-        let cssText =
+        const cssText =
             stringifier.stringify(parser.parse(fixtures.pathologicalComments));
         expect(cssText).to.be.eql(
             '.foo{bar:/*baz*/vim;}/* unclosed\n@fiz {\n  --huk: {\n    /* buz */baz:lur;@gak wiz;');

--- a/src/test/test-node-factory.ts
+++ b/src/test/test-node-factory.ts
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 /**
@@ -15,34 +16,34 @@ import {nodeType} from '../shady-css';
 
 export class TestNodeFactory {
   stylesheet(rules: any[]): any {
-    return { type: nodeType.stylesheet, rules };
+    return {type: nodeType.stylesheet, rules};
   }
 
-  atRule(name: string, parameters: string, rulelist: any|
-        undefined=undefined): any {
-    return { type: nodeType.atRule, name, parameters, rulelist };
+  atRule(name: string, parameters: string, rulelist: any|undefined = undefined):
+      any {
+    return {type: nodeType.atRule, name, parameters, rulelist};
   }
 
   comment(value: string): any {
-    return { type: nodeType.comment, value };
+    return {type: nodeType.comment, value};
   }
 
   rulelist(rules: any[]): any {
-    return { type: nodeType.rulelist, rules };
+    return {type: nodeType.rulelist, rules};
   }
 
   ruleset(selector: string, rulelist: any): any {
-    return { type: nodeType.ruleset, selector, rulelist };
+    return {type: nodeType.ruleset, selector, rulelist};
   }
 
   declaration(name: string, value: any|undefined): any {
-    return { type: nodeType.declaration, name, value };
+    return {type: nodeType.declaration, name, value};
   }
   expression(text: string): any {
-    return { type: nodeType.expression, text};
+    return {type: nodeType.expression, text};
   }
 
   discarded(text: string): any {
-    return { type: nodeType.discarded, text};
+    return {type: nodeType.discarded, text};
   }
 }

--- a/src/test/token-test.ts
+++ b/src/test/token-test.ts
@@ -14,7 +14,7 @@ import {Token} from '../shady-css/token';
 
 describe('Token', () => {
   it('supports bitfield type comparison', () => {
-    let token = new Token(128 | 32 | 2, 0, 0);
+    const token = new Token(128 | 32 | 2, 0, 0);
     expect(token.is(2)).to.be.ok;
     expect(token.is(4)).to.not.be.ok;
     expect(token.is(32 | 2)).to.be.ok;

--- a/src/test/token-test.ts
+++ b/src/test/token-test.ts
@@ -1,15 +1,16 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import { expect } from 'chai';
-import { Token } from '../shady-css/token';
+import {expect} from 'chai';
+import {Token} from '../shady-css/token';
 
 describe('Token', () => {
   it('supports bitfield type comparison', () => {

--- a/src/test/tokenizer-test.ts
+++ b/src/test/tokenizer-test.ts
@@ -1,34 +1,39 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-import { expect } from 'chai';
+import {expect} from 'chai';
+
+import {Token} from '../shady-css/token';
+import {Tokenizer} from '../shady-css/tokenizer';
+
 import * as fixtures from './fixtures';
 import * as helpers from './helpers';
-import { Tokenizer } from '../shady-css/tokenizer';
-import { Token } from '../shady-css/token';
 
 describe('Tokenizer', () => {
   describe('when tokenizing basic structures', () => {
     it('can identify strings', () => {
-      expect(new Tokenizer('"foo"').flush()).to.be.eql(
-          helpers.linkedTokens([new Token(Token.type.string, 0, 5)]));
+      expect(new Tokenizer('"foo"').flush()).to.be.eql(helpers.linkedTokens([
+        new Token(Token.type.string, 0, 5)
+      ]));
     });
 
     it('can identify comments', () => {
-      expect(new Tokenizer('/*foo*/').flush()).to.be.eql(
-          helpers.linkedTokens([new Token(Token.type.comment, 0, 7)]));
+      expect(new Tokenizer('/*foo*/').flush()).to.be.eql(helpers.linkedTokens([
+        new Token(Token.type.comment, 0, 7)
+      ]));
     });
 
     it('can identify words', () => {
-      expect(new Tokenizer('font-family').flush()).to.be.eql(
-          helpers.linkedTokens([new Token(Token.type.word, 0, 11)]));
+      expect(new Tokenizer('font-family').flush())
+          .to.be.eql(helpers.linkedTokens([new Token(Token.type.word, 0, 11)]));
     });
 
     it('can identify boundaries', () => {
@@ -46,93 +51,98 @@ describe('Tokenizer', () => {
   describe('when tokenizing standard CSS structures', () => {
     it('can tokenize a basic ruleset', () => {
       helpers.expectTokenSequence(new Tokenizer(fixtures.basicRuleset), [
-        Token.type.whitespace, '\n',
-        Token.type.word,       'body',
-        Token.type.whitespace, ' ',
-        Token.type.openBrace,  '{',
-        Token.type.whitespace, '\n  ',
-        Token.type.word,       'margin',
-        Token.type.colon,            ':',
-        Token.type.whitespace, ' ',
-        Token.type.word,       '0',
-        Token.type.semicolon,  ';',
-        Token.type.whitespace, '\n  ',
-        Token.type.word,       'padding',
-        Token.type.colon,            ':',
-        Token.type.whitespace, ' ',
-        Token.type.word,       '0px',
-        Token.type.whitespace, '\n',
-        Token.type.closeBrace, '}',
-        Token.type.whitespace, '\n'
+        Token.type.whitespace, '\n',   Token.type.word,       'body',
+        Token.type.whitespace, ' ',    Token.type.openBrace,  '{',
+        Token.type.whitespace, '\n  ', Token.type.word,       'margin',
+        Token.type.colon,      ':',    Token.type.whitespace, ' ',
+        Token.type.word,       '0',    Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n  ', Token.type.word,       'padding',
+        Token.type.colon,      ':',    Token.type.whitespace, ' ',
+        Token.type.word,       '0px',  Token.type.whitespace, '\n',
+        Token.type.closeBrace, '}',    Token.type.whitespace, '\n'
       ]);
     });
 
     it('can tokenize @rules', () => {
       helpers.expectTokenSequence(new Tokenizer(fixtures.atRules), [
-        Token.type.whitespace,       '\n',
-        Token.type.at,               '@',
-        Token.type.word,             'import',
-        Token.type.whitespace,       ' ',
-        Token.type.word,             'url',
-        Token.type.openParenthesis,  '(',
-        Token.type.string,           '\'foo.css\'',
-        Token.type.closeParenthesis, ')',
-        Token.type.semicolon,        ';',
-        Token.type.whitespace,       '\n\n',
-        Token.type.at,               '@',
-        Token.type.word,             'font-face',
-        Token.type.whitespace,       ' ',
-        Token.type.openBrace,        '{',
-        Token.type.whitespace,       '\n  ',
-        Token.type.word,             'font-family',
-        Token.type.colon,            ':',
-        Token.type.whitespace,       ' ',
-        Token.type.word,             'foo',
-        Token.type.semicolon,        ';',
-        Token.type.whitespace,       '\n',
-        Token.type.closeBrace,       '}',
-        Token.type.whitespace,       '\n\n',
-        Token.type.at,               '@',
-        Token.type.word,             'charset',
-        Token.type.whitespace,       ' ',
-        Token.type.string,           '\'foo\'',
-        Token.type.semicolon,        ';',
-        Token.type.whitespace,       '\n'
+        Token.type.whitespace,
+        '\n',
+        Token.type.at,
+        '@',
+        Token.type.word,
+        'import',
+        Token.type.whitespace,
+        ' ',
+        Token.type.word,
+        'url',
+        Token.type.openParenthesis,
+        '(',
+        Token.type.string,
+        '\'foo.css\'',
+        Token.type.closeParenthesis,
+        ')',
+        Token.type.semicolon,
+        ';',
+        Token.type.whitespace,
+        '\n\n',
+        Token.type.at,
+        '@',
+        Token.type.word,
+        'font-face',
+        Token.type.whitespace,
+        ' ',
+        Token.type.openBrace,
+        '{',
+        Token.type.whitespace,
+        '\n  ',
+        Token.type.word,
+        'font-family',
+        Token.type.colon,
+        ':',
+        Token.type.whitespace,
+        ' ',
+        Token.type.word,
+        'foo',
+        Token.type.semicolon,
+        ';',
+        Token.type.whitespace,
+        '\n',
+        Token.type.closeBrace,
+        '}',
+        Token.type.whitespace,
+        '\n\n',
+        Token.type.at,
+        '@',
+        Token.type.word,
+        'charset',
+        Token.type.whitespace,
+        ' ',
+        Token.type.string,
+        '\'foo\'',
+        Token.type.semicolon,
+        ';',
+        Token.type.whitespace,
+        '\n'
       ]);
     });
 
     it('navigates pathological boundary usage', () => {
       helpers.expectTokenSequence(new Tokenizer(fixtures.extraSemicolons), [
-        Token.type.whitespace, '\n',
-        Token.type.colon,      ':',
-        Token.type.word,       'host',
-        Token.type.whitespace, ' ',
-        Token.type.openBrace,  '{',
-        Token.type.whitespace, '\n  ',
-        Token.type.word,       'margin',
-        Token.type.colon,      ':',
-        Token.type.whitespace, ' ',
-        Token.type.word,       '0',
-        Token.type.semicolon,  ';',
-        Token.type.semicolon,  ';',
-        Token.type.semicolon,  ';',
-        Token.type.whitespace, '\n  ',
-        Token.type.word,       'padding',
-        Token.type.colon,      ':',
-        Token.type.whitespace, ' ',
-        Token.type.word,       '0',
-        Token.type.semicolon,  ';',
-        Token.type.semicolon,  ';',
-        Token.type.whitespace, '\n  ',
-        Token.type.semicolon,  ';',
-        Token.type.word,       'display',
-        Token.type.colon,      ':',
-        Token.type.whitespace, ' ',
-        Token.type.word,       'block',
-        Token.type.semicolon,  ';',
-        Token.type.whitespace, '\n',
-        Token.type.closeBrace, '}',
-        Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n',      Token.type.colon,      ':',
+        Token.type.word,       'host',    Token.type.whitespace, ' ',
+        Token.type.openBrace,  '{',       Token.type.whitespace, '\n  ',
+        Token.type.word,       'margin',  Token.type.colon,      ':',
+        Token.type.whitespace, ' ',       Token.type.word,       '0',
+        Token.type.semicolon,  ';',       Token.type.semicolon,  ';',
+        Token.type.semicolon,  ';',       Token.type.whitespace, '\n  ',
+        Token.type.word,       'padding', Token.type.colon,      ':',
+        Token.type.whitespace, ' ',       Token.type.word,       '0',
+        Token.type.semicolon,  ';',       Token.type.semicolon,  ';',
+        Token.type.whitespace, '\n  ',    Token.type.semicolon,  ';',
+        Token.type.word,       'display', Token.type.colon,      ':',
+        Token.type.whitespace, ' ',       Token.type.word,       'block',
+        Token.type.semicolon,  ';',       Token.type.whitespace, '\n',
+        Token.type.closeBrace, '}',       Token.type.semicolon,  ';',
         Token.type.whitespace, '\n'
       ]);
     });
@@ -142,8 +152,7 @@ describe('Tokenizer', () => {
     it('can slice the string using tokens', () => {
       let tokenizer = new Tokenizer('foo bar');
       let substring = tokenizer.slice(
-          new Token(Token.type.word, 2, 3),
-          new Token(Token.type.word, 5, 6));
+          new Token(Token.type.word, 2, 3), new Token(Token.type.word, 5, 6));
       expect(substring).to.be.eql('o ba');
     });
   });

--- a/src/test/tokenizer-test.ts
+++ b/src/test/tokenizer-test.ts
@@ -150,8 +150,8 @@ describe('Tokenizer', () => {
 
   describe('when extracting substrings', () => {
     it('can slice the string using tokens', () => {
-      let tokenizer = new Tokenizer('foo bar');
-      let substring = tokenizer.slice(
+      const tokenizer = new Tokenizer('foo bar');
+      const substring = tokenizer.slice(
           new Token(Token.type.word, 2, 3), new Token(Token.type.word, 5, 6));
       expect(substring).to.be.eql('o ba');
     });

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,60 @@
+{
+  "rules": {
+      "arrow-parens": true,
+      "class-name": true,
+      "indent": [
+          true,
+          "spaces"
+      ],
+      "prefer-const": true,
+      "no-duplicate-variable": true,
+      "no-eval": true,
+      "no-internal-module": true,
+      "no-trailing-whitespace": true,
+      "no-var-keyword": true,
+      "one-line": [
+          true,
+          "check-open-brace",
+          "check-whitespace"
+      ],
+      "quotemark": [
+          true,
+          "single",
+          "avoid-escape"
+      ],
+      "semicolon": [
+          true,
+          "always"
+      ],
+      "trailing-comma": [
+          true,
+          "multiline"
+      ],
+      "triple-equals": [
+          true,
+          "allow-null-check"
+      ],
+      "typedef-whitespace": [
+          true,
+          {
+              "call-signature": "nospace",
+              "index-signature": "nospace",
+              "parameter": "nospace",
+              "property-declaration": "nospace",
+              "variable-declaration": "nospace"
+          }
+      ],
+      "variable-name": [
+          true,
+          "ban-keywords"
+      ],
+      "whitespace": [
+          true,
+          "check-branch",
+          "check-decl",
+          "check-operator",
+          "check-separator",
+          "check-type"
+      ]
+  }
+}


### PR DESCRIPTION
This change is a very boring noop change. Besides package.json the rest are autogenerated formatting and automatic lint fixes.

/cc @cdata 